### PR TITLE
Implement outbound call hangups

### DIFF
--- a/pkg/sip/server.go
+++ b/pkg/sip/server.go
@@ -124,7 +124,7 @@ func sipErrorResponse(tx sip.ServerTransaction, req *sip.Request) {
 	_ = tx.Respond(sip.NewResponseFromRequest(req, 400, "", nil))
 }
 
-func (s *Server) Start(agent *sipgo.UserAgent) error {
+func (s *Server) Start() error {
 	var err error
 	if s.conf.UseExternalIP {
 		if s.signalingIp, err = getPublicIP(); err != nil {
@@ -138,14 +138,11 @@ func (s *Server) Start(agent *sipgo.UserAgent) error {
 		}
 	}
 
-	if agent == nil {
-		ua, err := sipgo.NewUA(
-			sipgo.WithUserAgent(UserAgent),
-		)
-		if err != nil {
-			return err
-		}
-		agent = ua
+	agent, err := sipgo.NewUA(
+		sipgo.WithUserAgent(UserAgent),
+	)
+	if err != nil {
+		return err
 	}
 
 	s.sipSrv, err = sipgo.NewServer(agent)

--- a/pkg/sip/service.go
+++ b/pkg/sip/service.go
@@ -15,7 +15,6 @@
 package sip
 
 import (
-	"github.com/emiago/sipgo"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
 	"golang.org/x/exp/maps"
@@ -76,16 +75,11 @@ func (s *Service) Start() error {
 	if err := s.mon.Start(s.conf); err != nil {
 		return err
 	}
-	ua, err := sipgo.NewUA(
-		sipgo.WithUserAgent(UserAgent),
-	)
-	if err != nil {
+
+	if err := s.cli.Start(); err != nil {
 		return err
 	}
-	if err = s.cli.Start(ua); err != nil {
-		return err
-	}
-	if err = s.srv.Start(ua); err != nil {
+	if err := s.srv.Start(); err != nil {
 		return err
 	}
 	logger.Debugw("sip service ready")


### PR DESCRIPTION
* Outbound was sharing a port with server. BYE requests would be routed into the server handler. We no longer share the UserAgent so Outbound+Inbound is happening on distinct ports

* Add `Bye` handler to Outbound handler

* Properly build the outbound INVITE request. From header didn't include the CallerID

* Properly build the outbound Ack. Was missing Record-Route