### PR TITLE
Revert UA change. Pass BYE from server to client.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	ClusterID      string              `yaml:"cluster_id"` // cluster this instance belongs to
 
 	UseExternalIP bool   `yaml:"use_external_ip"`
+	LocalNet      string `yaml:"local_net"` // local IP net to use, e.g. 192.168.0.0/24
 	NAT1To1IP     string `yaml:"nat_1_to_1_ip"`
 
 	// internal

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -187,6 +187,8 @@ func (s *Server) onBye(req *sip.Request, tx sip.ServerTransaction) {
 	s.cmu.RUnlock()
 	if c != nil {
 		c.Close()
+	} else if s.sipUnhandled != nil {
+		s.sipUnhandled(req, tx)
 	}
 	_ = tx.Respond(sip.NewResponseFromRequest(req, 200, "OK", nil))
 }

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -311,6 +311,34 @@ func (c *outboundCall) sipAttemptInvite(offer []byte, conf sipOutboundConfig, au
 	req.AppendHeader(&sip.ToHeader{Address: *to})
 	req.AppendHeader(fromHeader)
 	req.AppendHeader(&sip.ContactHeader{Address: *from})
+	// TODO: This issue came out when we tried creating separate UA for the server and the client.
+	//       So we might need to set Via explicitly. Anyway, UA must be shared for other reasons,
+	//       and the calls work without explicit Via. So keep it simple, and let SIPGO set Via for now.
+	//       Code will remain here for the future reference/refactoring.
+	if false {
+		if c.c.signalingIp != c.c.signalingIpLocal {
+			// SIPGO will use Via/From headers to figure out which interface to listen on, which will obviously fail
+			// in case we specify our external IP in there. So we must explicitly add a Via with our local IP.
+			params := sip.NewParams()
+			params["branch"] = sip.GenerateBranch()
+			req.AppendHeader(&sip.ViaHeader{
+				ProtocolName:    "SIP",
+				ProtocolVersion: "2.0",
+				Transport:       req.Transport(),
+				Host:            c.c.signalingIpLocal,
+				Params:          params,
+			})
+		}
+		params := sip.NewParams()
+		params["branch"] = sip.GenerateBranch()
+		req.AppendHeader(&sip.ViaHeader{
+			ProtocolName:    "SIP",
+			ProtocolVersion: "2.0",
+			Transport:       req.Transport(),
+			Host:            c.c.signalingIp,
+			Params:          params,
+		})
+	}
 	req.AppendHeader(sip.NewHeader("Content-Type", "application/sdp"))
 	req.AppendHeader(sip.NewHeader("Allow", "INVITE, ACK, CANCEL, BYE, NOTIFY, REFER, MESSAGE, OPTIONS, INFO, SUBSCRIBE"))
 


### PR DESCRIPTION
Revert UA change. We must share the UA to keep a single SIP signaling port (and thus the forwarding setup)

Pass unhandled BYE from server to client, so that the outbound call can properly terminate.

Also, allow specifying which local interface to use in the config.