### PR TITLE
Add media timeout check to MediaConn

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -373,7 +373,9 @@ func (c *inboundCall) runMediaConn(offerData []byte, conf *config.Config) (answe
 	if err := offer.Unmarshal(offerData); err != nil {
 		return nil, err
 	}
-	conn := rtp.NewConn()
+	conn := rtp.NewConn(func() {
+		c.close("media-timeout")
+	})
 	conn.OnRTP(&rtpStatsHandler{mon: c.mon, h: c})
 	if dst := sdpGetAudioDest(offer); dst != nil {
 		conn.SetDestAddr(dst)

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -58,9 +58,12 @@ type outboundCall struct {
 
 func (c *Client) newCall(conf *config.Config, room lkRoomConfig) (*outboundCall, error) {
 	call := &outboundCall{
-		c:       c,
-		rtpConn: rtp.NewConn(),
+		c: c,
 	}
+	call.rtpConn = rtp.NewConn(func() {
+		call.close("media-timeout")
+	})
+
 	if err := call.startMedia(conf); err != nil {
 		call.close("media-failed")
 		return nil, fmt.Errorf("start media failed: %w", err)

--- a/pkg/siptest/client.go
+++ b/pkg/siptest/client.go
@@ -83,7 +83,9 @@ func NewClient(id string, conf ClientConfig) (*Client, error) {
 			SSRC:    5000,
 		},
 	}
-	cli.media = lkrtp.NewConn()
+	cli.media = lkrtp.NewConn(func() {
+		panic("media-timeout")
+	})
 
 	err := cli.media.Listen(0, 0, "0.0.0.0")
 	if err != nil {


### PR DESCRIPTION
If no RTP packets are seen for 30 seconds timeout the call