### PR TITLE
Correctly set RTP timestamps when delaying DTMF

### DIFF
--- a/pkg/media/dtmf/dtmf_test.go
+++ b/pkg/media/dtmf/dtmf_test.go
@@ -15,10 +15,13 @@
 package dtmf
 
 import (
+	"context"
 	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/sip/pkg/media/rtp"
 )
 
 func TestDTMF(t *testing.T) {
@@ -67,4 +70,15 @@ func TestDTMF(t *testing.T) {
 			require.Equal(t, c.data, hex.EncodeToString(buf[:n]))
 		})
 	}
+}
+
+func TestDTMFDelay(t *testing.T) {
+	var buf rtp.Buffer
+	w := rtp.NewSeqWriter(&buf).NewStream(101)
+	err := WriteRTP(context.Background(), w, "1w23")
+	require.NoError(t, err)
+	require.Len(t, buf, 3)
+	require.EqualValues(t, 0, buf[0].Timestamp)
+	require.EqualValues(t, rtp.DefSampleRate/2+rtp.DefPacketDur, buf[1].Timestamp)
+	require.EqualValues(t, rtp.DefSampleRate/2+rtp.DefPacketDur*2, buf[2].Timestamp)
 }

--- a/pkg/media/rtp/codecs.go
+++ b/pkg/media/rtp/codecs.go
@@ -37,7 +37,7 @@ func CodecByPayloadType(typ byte) media.Codec {
 
 type AudioCodec interface {
 	media.Codec
-	EncodeRTP(w *Stream, typ byte) media.PCM16Writer
+	EncodeRTP(w *Stream) media.PCM16Writer
 	DecodeRTP(w media.PCM16Writer, typ byte) Handler
 }
 
@@ -79,8 +79,8 @@ func (c *audioCodec[S]) Encode(w media.Writer[S]) media.PCM16Writer {
 	return c.encode(w)
 }
 
-func (c *audioCodec[S]) EncodeRTP(w *Stream, typ byte) media.PCM16Writer {
-	return c.encode(NewMediaStreamFor[S](w, typ))
+func (c *audioCodec[S]) EncodeRTP(w *Stream) media.PCM16Writer {
+	return c.encode(NewMediaStreamOut[S](w))
 }
 
 func (c *audioCodec[S]) DecodeRTP(w media.PCM16Writer, typ byte) Handler {

--- a/pkg/media/rtp/media.go
+++ b/pkg/media/rtp/media.go
@@ -17,8 +17,13 @@ package rtp
 import "time"
 
 const (
-	DefSampleRate    = 8000
-	DefSampleDur     = 20 * time.Millisecond
-	DefSampleDurPart = int(time.Second / DefSampleDur)
-	DefPacketDur     = uint32(DefSampleRate / DefSampleDurPart)
+	// DefSampleRate is a default number of audio samples per second.
+	DefSampleRate = 8000
+	// DefFrameDur is a default duration of an audio frame.
+	DefFrameDur = 20 * time.Millisecond
+	// DefFrameRate is a default number of audio frames per second.
+	DefFrameRate = int(time.Second / DefFrameDur)
+	// DefPacketDur is a default duration of frame packet in DefFrameDur units (aka samples per frame).
+	// It is used as an increment for RTP timestamps.
+	DefPacketDur = uint32(DefSampleRate / DefFrameRate)
 )

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -406,8 +406,9 @@ func (c *inboundCall) runMediaConn(offerData []byte, conf *config.Config) (answe
 
 	// Encoding pipeline (LK -> SIP)
 	// Need to be created earlier to send the pin prompts.
-	s := rtp.NewStream(newRTPStatsWriter(c.mon, "audio", conn), rtp.DefPacketDur)
-	audio := c.audioCodec.EncodeRTP(s, c.audioType)
+	s := rtp.NewSeqWriter(newRTPStatsWriter(c.mon, "audio", conn))
+	sa := s.NewStream(c.audioType)
+	audio := c.audioCodec.EncodeRTP(sa)
 	c.lkRoom.SetOutput(audio)
 
 	return sdpGenerateAnswer(offer, c.s.signalingIp, conn.LocalAddr().Port, res)

--- a/pkg/sip/room.go
+++ b/pkg/sip/room.go
@@ -55,7 +55,7 @@ type lkRoomConfig struct {
 
 func NewRoom() *Room {
 	r := &Room{}
-	r.mix = mixer.NewMixer(&r.out, rtp.DefSampleDur, rtp.DefSampleRate)
+	r.mix = mixer.NewMixer(&r.out, rtp.DefFrameDur, rtp.DefSampleRate)
 	return r
 }
 
@@ -163,7 +163,7 @@ func (r *Room) NewParticipantTrack() (media.Writer[media.PCM16Sample], error) {
 	}); err != nil {
 		return nil, err
 	}
-	ow := media.FromSampleWriter[opus.Sample](track, rtp.DefSampleDur)
+	ow := media.FromSampleWriter[opus.Sample](track, rtp.DefFrameDur)
 	pw, err := opus.Encode(ow, rtp.DefSampleRate, channels)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func (t *Track) Close() error {
 }
 
 func (t *Track) PlayAudio(ctx context.Context, frames []media.PCM16Sample) {
-	_ = media.PlayAudio[media.PCM16Sample](ctx, t, rtp.DefSampleDur, frames)
+	_ = media.PlayAudio[media.PCM16Sample](ctx, t, rtp.DefFrameDur, frames)
 }
 
 func (t *Track) WriteSample(pcm media.PCM16Sample) error {

--- a/test/lktest/livekit.go
+++ b/test/lktest/livekit.go
@@ -113,7 +113,7 @@ func (lk *LiveKit) ConnectParticipant(t TB, room, identity string, cb *lksdk.Roo
 		pr.Close()
 	})
 	p.AudioIn = pr
-	p.mix = mixer.NewMixer(pw, rtp.DefSampleDur, rtp.DefSampleRate)
+	p.mix = mixer.NewMixer(pw, rtp.DefFrameDur, rtp.DefSampleRate)
 	cb.ParticipantCallback.OnTrackPublished = func(pub *lksdk.RemoteTrackPublication, rp *lksdk.RemoteParticipant) {
 		if pub.Kind() == lksdk.TrackKindAudio {
 			if err := pub.SetSubscribed(true); err != nil {
@@ -161,7 +161,7 @@ func (p *Participant) newAudioTrack() (media.Writer[media.PCM16Sample], error) {
 	}); err != nil {
 		return nil, err
 	}
-	ow := media.FromSampleWriter[opus.Sample](track, rtp.DefSampleDur)
+	ow := media.FromSampleWriter[opus.Sample](track, rtp.DefFrameDur)
 	pw, err := opus.Encode(ow, rtp.DefSampleRate, channels)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (p *Participant) SendSignal(ctx context.Context, n int, val int) error {
 	audiotest.GenSignal(signal, []audiotest.Wave{{Ind: val, Amp: signalAmp}})
 	p.t.Log("sending signal", "len", len(signal), "n", n, "sig", val)
 
-	ticker := time.NewTicker(rtp.DefSampleDur)
+	ticker := time.NewTicker(rtp.DefFrameDur)
 	defer ticker.Stop()
 	i := 0
 	for {
@@ -208,7 +208,7 @@ func (p *Participant) SendSignal(ctx context.Context, n int, val int) error {
 func (c *Participant) WaitSignals(ctx context.Context, vals []int, w io.WriteCloser) error {
 	var ws media.PCM16WriteCloser
 	if w != nil {
-		ws = webmm.NewPCM16Writer(w, rtp.DefSampleRate, rtp.DefSampleDur)
+		ws = webmm.NewPCM16Writer(w, rtp.DefSampleRate, rtp.DefFrameDur)
 		defer ws.Close()
 	}
 	lastLog := time.Now()


### PR DESCRIPTION
Split audio and DTMF  RTP streams and accumulate timestamps independently. Update RTP timestamp properly when applying DTMF delay. 