### PR TITLE
Revert separate SSRC

### DIFF
--- a/pkg/media/rtp/rtp.go
+++ b/pkg/media/rtp/rtp.go
@@ -77,12 +77,6 @@ func NewSeqWriter(w Writer) *SeqWriter {
 	return s
 }
 
-// NewStream creates an RTP stream with a given payload time that automatically increments sequence number.
-func NewStream(w Writer, typ byte, clockRate int) *Stream {
-	sq := NewSeqWriter(w)
-	return sq.NewStream(typ, clockRate)
-}
-
 type Packet = rtp.Packet
 
 type Event struct {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -464,11 +464,12 @@ func (c *inboundCall) runMediaConn(offerData []byte, conf *config.Config) (answe
 
 	// Encoding pipeline (LK -> SIP)
 	// Must be created earlier to send the pin prompts.
-	sa := rtp.NewStream(newRTPStatsWriter(c.mon, "audio", conn), c.audioType, c.audioCodec.Info().RTPClockRate)
+	s := rtp.NewSeqWriter(newRTPStatsWriter(c.mon, "audio", conn))
+	sa := s.NewStream(c.audioType, c.audioCodec.Info().RTPClockRate)
 	audio := c.audioCodec.EncodeRTP(sa)
 	c.lkRoom.SetOutput(audio)
 	if res.DTMFType != 0 {
-		sd := rtp.NewStream(newRTPStatsWriter(c.mon, "dtmf", conn), res.DTMFType, dtmf.SampleRate)
+		sd := s.NewStream(res.DTMFType, dtmf.SampleRate)
 		c.lkRoom.SetDTMFOutput(sd)
 	}
 


### PR DESCRIPTION
Seems like reusing the SSRC was spec-compliant after all. Provider tests were failing without it.