### PR TITLE
Add nil check to prevent panic if room is not connected

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -575,7 +575,7 @@ func (c *inboundCall) closeMedia() {
 }
 
 func (c *inboundCall) setStatus(v CallStatus) {
-	if c.lkRoom == nil {
+	if c.lkRoom == nil || c.lkRoom.Room() == nil || c.lkRoom.Room().LocalParticipant == nil {
 		return
 	}
 	r := c.lkRoom.Room()

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -575,13 +575,14 @@ func (c *inboundCall) closeMedia() {
 }
 
 func (c *inboundCall) setStatus(v CallStatus) {
-	if c.lkRoom == nil || c.lkRoom.Room() == nil || c.lkRoom.Room().LocalParticipant == nil {
+	if c.lkRoom == nil {
 		return
 	}
 	r := c.lkRoom.Room()
-	if r == nil {
+	if r == nil || r.LocalParticipant == nil {
 		return
 	}
+
 	r.LocalParticipant.SetAttributes(map[string]string{
 		AttrSIPCallStatus: string(v),
 	})


### PR DESCRIPTION
The stack trace of the panic shows that this happens in the case where the SIP server never finishes the handshake. This means that the SDK never connects to the room, and LocalParticipant is nil when handling the connection time out