### PR TITLE
Improve metrics, make it safer

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -157,7 +157,7 @@ func (s *Server) onInvite(req *sip.Request, tx sip.ServerTransaction) {
 		return
 	}
 
-	cmon := s.mon.NewCall(stats.Inbound, from.Address.String(), to.Address.String())
+	cmon := s.mon.NewCall(stats.Inbound, from.Address.Host, to.Address.Host)
 
 	cmon.InviteReq()
 	defer cmon.SessionDur()()

--- a/pkg/sip/room.go
+++ b/pkg/sip/room.go
@@ -79,6 +79,9 @@ func (r *Room) Closed() <-chan struct{} {
 }
 
 func (r *Room) Room() *lksdk.Room {
+	if r == nil {
+		return nil
+	}
 	return r.room
 }
 
@@ -240,6 +243,9 @@ func (r *Room) sendDTMF(msg *livekit.SipDTMF) {
 }
 
 func (r *Room) Close() error {
+	if r == nil {
+		return nil
+	}
 	r.ready.Store(false)
 	err := r.CloseOutput()
 	r.SetDTMFOutput(nil)


### PR DESCRIPTION
A few small-ish fixes for the metrics:
- Simplify outbound code a bit.
- Make sure outbound call metric is decreased.
- Adjust duration buckets for short and long operations.
- Use from/to host instead of a full URI or the number for the metric.