### PR TITLE
Change the call flow. Defer track subscription.

### DIFF
--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -29,6 +29,7 @@ import (
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
 	"github.com/livekit/psrpc"
+
 	"github.com/livekit/sip/pkg/stats"
 
 	"github.com/livekit/sip/pkg/config"
@@ -167,7 +168,7 @@ func (s *Service) Run() error {
 	}
 }
 
-func (s *Service) GetAuthCredentials(ctx context.Context, from, to, toHost, srcAddress string) (username, password string, drop bool, err error) {
+func (s *Service) GetAuthCredentials(ctx context.Context, from, to, toHost, srcAddress string) (sip.AuthInfo, error) {
 	return GetAuthCredentials(ctx, s.psrpcClient, from, to, toHost, srcAddress)
 }
 

--- a/pkg/sip/client.go
+++ b/pkg/sip/client.go
@@ -189,7 +189,6 @@ func (c *Client) onBye(req *sip.Request, tx sip.ServerTransaction) bool {
 	call := c.byRemote[tag]
 	c.cmu.Unlock()
 	if call == nil {
-		c.log.Infow("BYE", "sipTag", tag)
 		return false
 	}
 	call.log.Infow("BYE")

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -16,8 +16,10 @@ package sip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -41,14 +43,6 @@ const (
 	// This is done because of audio cutoff at the beginning of calls observed in the wild.
 	audioBridgeMaxDelay = 1 * time.Second
 )
-
-func (s *Server) sipErrorOrDrop(tx sip.ServerTransaction, req *sip.Request) {
-	if s.conf.HideInboundPort {
-		tx.Terminate()
-	} else {
-		sipErrorResponse(tx, req)
-	}
-}
 
 func (s *Server) handleInviteAuth(log logger.Logger, req *sip.Request, tx sip.ServerTransaction, from, username, password string) (ok bool) {
 	if username == "" || password == "" {
@@ -126,77 +120,66 @@ func (s *Server) onInvite(req *sip.Request, tx sip.ServerTransaction) {
 		"fromIP", src,
 		"toIP", req.Destination(),
 	)
-	for hdr, name := range headerToLog {
-		if h := req.GetHeader(hdr); h != nil {
-			log = log.WithValues(name, h.Value())
+
+	cc := s.newInbound(LocalTag(callID), req, tx)
+	log = LoggerWithParams(log, cc)
+	log = LoggerWithHeaders(log, cc)
+	log.Infow("processing invite")
+
+	if err := cc.ValidateInvite(); err != nil {
+		if s.conf.HideInboundPort {
+			cc.Drop()
+		} else {
+			cc.RespondAndDrop(sip.StatusBadRequest, "Bad request")
 		}
-	}
-	log.Debugw("invite received")
-
-	if !s.conf.HideInboundPort {
-		_ = tx.Respond(sip.NewResponseFromRequest(req, 100, "Processing", nil))
-	}
-	tag, err := getFromTag(req)
-	if err != nil {
-		s.sipErrorOrDrop(tx, req)
-		return
-	}
-	log = log.WithValues(
-		"sipTag", tag,
-	)
-
-	from, ok := req.From()
-	if !ok {
-		s.sipErrorOrDrop(tx, req)
 		return
 	}
 
-	to, ok := req.To()
-	if !ok {
-		s.sipErrorOrDrop(tx, req)
-		return
-	}
+	from, to := cc.From(), cc.To()
 
-	cmon := s.mon.NewCall(stats.Inbound, from.Address.Host, to.Address.Host)
-
+	cmon := s.mon.NewCall(stats.Inbound, from.Host, cc.To().Host)
 	cmon.InviteReq()
 	defer cmon.SessionDur()()
 	joinDur := cmon.JoinDur()
-	log = log.WithValues(
-		"fromHost", from.Address.Host, "fromUser", from.Address.User,
-		"toHost", to.Address.Host, "toUser", to.Address.User,
-	)
-	log.Infow("processing invite")
 
-	username, password, drop, err := s.handler.GetAuthCredentials(ctx, from.Address.User, to.Address.User, to.Address.Host, src)
+	if !s.conf.HideInboundPort {
+		cc.Processing()
+	}
+
+	r, err := s.handler.GetAuthCredentials(ctx, from.User, to.User, to.Host, src)
 	if err != nil {
-		cmon.InviteErrorShort("no-rule")
-		log.Warnw("Rejecting inbound, doesn't match any Trunks", err)
-		sipErrorResponse(tx, req)
+		cmon.InviteErrorShort("auth-error")
+		log.Warnw("Rejecting inbound, auth check failed", err)
+		cc.RespondAndDrop(sip.StatusServiceUnavailable, "Try again later")
 		return
-	} else if drop {
+	}
+	switch r.Result {
+	case AuthDrop:
 		cmon.InviteErrorShort("flood")
 		log.Debugw("Dropping inbound flood")
-		tx.Terminate()
+		cc.Drop()
 		return
-	}
-	if !s.handleInviteAuth(log, req, tx, from.Address.User, username, password) {
-		cmon.InviteErrorShort("unauthorized")
-		// handleInviteAuth will generate the SIP Response as needed
+	case AuthNotFound:
+		cmon.InviteErrorShort("no-rule")
+		log.Warnw("Rejecting inbound, doesn't match any Trunks", nil)
+		cc.RespondAndDrop(sip.StatusNotFound, "Does not match any SIP Trunks")
 		return
-	}
-	cmon.InviteAccept()
-	if !s.conf.HideInboundPort {
-		_ = tx.Respond(sip.NewResponseFromRequest(req, 180, "Ringing", nil))
+	case AuthPassword:
+		if s.conf.HideInboundPort {
+			// We will send password request anyway, so might as well signal that the progress is made.
+			cc.Processing()
+		}
+		if !s.handleInviteAuth(log, req, tx, from.User, r.Username, r.Password) {
+			cmon.InviteErrorShort("unauthorized")
+			// handleInviteAuth will generate the SIP Response as needed
+			return
+		}
+		fallthrough
+	case AuthAccept:
+		// ok
 	}
 
-	extra := make(map[string]string)
-	for hdr, name := range headerToAttr {
-		if h := req.GetHeader(hdr); h != nil {
-			extra[name] = h.Value()
-		}
-	}
-	call := s.newInboundCall(log, cmon, LocalTag(callID), tag, from, to, src, extra)
+	call := s.newInboundCall(log, cmon, cc, src, nil)
 	call.joinDur = joinDur
 	call.handleInvite(call.ctx, req, tx, s.conf)
 }
@@ -204,7 +187,7 @@ func (s *Server) onInvite(req *sip.Request, tx sip.ServerTransaction) {
 func (s *Server) onBye(req *sip.Request, tx sip.ServerTransaction) {
 	tag, err := getFromTag(req)
 	if err != nil {
-		sipErrorResponse(tx, req)
+		_ = tx.Respond(sip.NewResponseFromRequest(req, 400, "", nil))
 		return
 	}
 
@@ -212,8 +195,8 @@ func (s *Server) onBye(req *sip.Request, tx sip.ServerTransaction) {
 	c := s.activeCalls[tag]
 	s.cmu.RUnlock()
 	if c != nil {
-		_ = tx.Respond(sip.NewResponseFromRequest(req, 200, "OK", nil))
 		c.log.Infow("BYE")
+		c.cc.AcceptBye(req, tx)
 		c.Close()
 		return
 	}
@@ -223,22 +206,18 @@ func (s *Server) onBye(req *sip.Request, tx sip.ServerTransaction) {
 	}
 	if !ok {
 		s.log.Infow("BYE for non-existent call", "sipTag", tag)
+		_ = tx.Respond(sip.NewResponseFromRequest(req, sip.StatusCallTransactionDoesNotExists, "Call does not exist", nil))
 	}
 }
 
 type inboundCall struct {
 	s           *Server
 	log         logger.Logger
+	cc          *sipInbound
 	mon         *stats.CallMonitor
-	id          LocalTag
-	tag         RemoteTag
 	extraAttrs  map[string]string
 	ctx         context.Context
 	cancel      func()
-	inviteReq   *sip.Request
-	inviteResp  *sip.Response
-	from        *sip.FromHeader
-	to          *sip.ToHeader
 	src         string
 	media       *MediaPort
 	dtmf        chan dtmf.Event // buffered
@@ -249,17 +228,13 @@ type inboundCall struct {
 	done        atomic.Bool
 }
 
-func (s *Server) newInboundCall(log logger.Logger, mon *stats.CallMonitor, id LocalTag, tag RemoteTag, from *sip.FromHeader, to *sip.ToHeader, src string, extra map[string]string) *inboundCall {
-	// Set the SIP tag for following requests from us to remote (e.g. BYE).
-	to.Params["tag"] = string(id)
+func (s *Server) newInboundCall(log logger.Logger, mon *stats.CallMonitor, cc *sipInbound, src string, extra map[string]string) *inboundCall {
+	extra = HeadersToAttrs(extra, cc)
 	c := &inboundCall{
 		s:          s,
 		log:        log,
 		mon:        mon,
-		id:         id,
-		tag:        tag,
-		from:       from,
-		to:         to,
+		cc:         cc,
 		src:        src,
 		extraAttrs: extra,
 		dtmf:       make(chan dtmf.Event, 10),
@@ -267,7 +242,7 @@ func (s *Server) newInboundCall(log logger.Logger, mon *stats.CallMonitor, id Lo
 	}
 	c.ctx, c.cancel = context.WithCancel(context.Background())
 	s.cmu.Lock()
-	s.activeCalls[tag] = c
+	s.activeCalls[cc.Tag()] = c
 	s.cmu.Unlock()
 	return c
 }
@@ -277,16 +252,19 @@ func (c *inboundCall) closeWithTimeout() {
 }
 
 func (c *inboundCall) handleInvite(ctx context.Context, req *sip.Request, tx sip.ServerTransaction, conf *config.Config) {
+	c.mon.InviteAccept()
 	c.mon.CallStart()
 	defer c.mon.CallEnd()
 	defer c.close(true, callDropped, "other")
+
+	c.cc.StartRinging()
 	// Send initial request. In the best case scenario, we will immediately get a room name to join.
 	// Otherwise, we could even learn that this number is not allowed and reject the call, or ask for pin if required.
 	disp := c.s.handler.DispatchCall(ctx, &CallInfo{
-		ID:         string(c.id),
-		FromUser:   c.from.Address.User,
-		ToUser:     c.to.Address.User,
-		ToHost:     c.to.Address.Host,
+		ID:         string(c.cc.ID()),
+		FromUser:   c.cc.From().User,
+		ToUser:     c.cc.To().User,
+		ToHost:     c.cc.To().Host,
 		SrcAddress: c.src,
 		Pin:        "",
 		NoPin:      false,
@@ -297,102 +275,82 @@ func (c *inboundCall) handleInvite(ctx context.Context, req *sip.Request, tx sip
 	if disp.DispatchRuleID != "" {
 		c.log = c.log.WithValues("sipRule", disp.DispatchRuleID)
 	}
+	var pinPrompt bool
 	switch disp.Result {
 	default:
 		c.log.Errorw("Rejecting inbound call", fmt.Errorf("unexpected dispatch result: %v", disp.Result))
-		sipErrorResponse(tx, req)
+		c.cc.RespondAndDrop(sip.StatusNotImplemented, "")
 		c.close(true, callDropped, "unexpected-result")
 		return
 	case DispatchNoRuleDrop:
 		c.log.Debugw("Rejecting inbound flood")
-		tx.Terminate()
+		c.cc.Drop()
 		c.close(false, callDropped, "flood")
 		return
 	case DispatchNoRuleReject:
 		c.log.Infow("Rejecting inbound call, doesn't match any Dispatch Rules")
-		sipErrorResponse(tx, req)
+		c.cc.RespondAndDrop(sip.StatusNotFound, "Does not match Trunks or Dispatch Rules")
 		c.close(false, callDropped, "no-dispatch")
 		return
-	case DispatchAccept, DispatchRequestPin:
-		// continue
+	case DispatchAccept:
+		pinPrompt = false
+	case DispatchRequestPin:
+		pinPrompt = true
 	}
 
 	// We need to start media first, otherwise we won't be able to send audio prompts to the caller, or receive DTMF.
 	answerData, err := c.runMediaConn(req.Body(), conf)
 	if err != nil {
 		c.log.Errorw("Cannot start media", err)
-		sipErrorResponse(tx, req)
+		c.cc.RespondAndDrop(sip.StatusInternalServerError, "")
 		c.close(true, callDropped, "media-failed")
 		return
 	}
-
-	res := sip.NewResponseFromRequest(req, 200, "OK", answerData)
-
-	// This will effectively redirect future SIP requests to this server instance (if signalingIp is not LB).
-	res.AppendHeader(&sip.ContactHeader{Address: sip.Uri{Host: c.s.signalingIp, Port: c.s.conf.SIPPort}})
-
-	// When behind LB, the source IP may be incorrect and/or the UDP "session" timeout may expire.
-	// This is critical for sending new requests like BYE.
-	//
-	// Thus, instead of relying on LB, we will contact the source IP directly (should be the first Via).
-	// BYE will also copy the same destination address from our response to INVITE.
-	if h, ok := req.Via(); ok && h.Host != "" {
-		port := 5060
-		if h.Port != 0 {
-			port = h.Port
+	acceptCall := func() bool {
+		c.log.Infow("Accepting the call")
+		if err = c.cc.Accept(c.s.signalingIp, c.s.conf.SIPPort, answerData); err != nil {
+			c.log.Errorw("Cannot respond to INVITE", err)
+			return false
 		}
-		res.SetDestination(fmt.Sprintf("%s:%d", h.Host, port))
+		c.media.EnableTimeout(true)
+		if !c.waitMedia(ctx) {
+			return false
+		}
+		return true
 	}
 
-	res.AppendHeader(&contentTypeHeaderSDP)
-	if err = tx.Respond(res); err != nil {
-		c.log.Infow("Cannot respond to INVITE", "error", err)
-		return
-	}
-	c.inviteReq = req
-	c.inviteResp = res
-
-	// Wait for either a first RTP packet or a predefined delay.
-	//
-	// If the delay kicks in earlier than the caller is ready, they might miss some audio packets.
-	//
-	// On the other hand, if we always wait for RTP, it might be harder to diagnose firewall/routing issues.
-	// In that case both sides will hear nothing, instead of only one side having issues.
-	//
-	// Thus, we wait at most a fixed amount of time before bridging audio.
-
-	// We own this goroutine, so can freely block.
-	delay := time.NewTimer(audioBridgeMaxDelay)
-	select {
-	case <-ctx.Done():
-		delay.Stop()
-		c.close(false, CallHangup, "hangup")
-		return
-	case <-c.media.Timeout():
-		delay.Stop()
-		c.closeWithTimeout()
-		return
-	case <-c.media.Received():
-		delay.Stop()
-	case <-delay.C:
-	}
-	switch disp.Result {
-	default:
-		c.log.Errorw("Rejecting inbound call", fmt.Errorf("unreachable dispatch result path: %v", disp.Result))
-		sipErrorResponse(tx, req)
-		c.close(true, callDropped, "unreachable-path")
-		return
-	case DispatchRequestPin:
+	if pinPrompt {
+		// Accept the call first on the SIP side, so that we can send audio prompts.
+		if !acceptCall() {
+			return // already sent a response
+		}
 		var ok bool
 		disp, ok = c.pinPrompt(ctx)
 		if !ok {
-			return // already sent response
+			return // already sent a response
 		}
-		// ok
-	case DispatchAccept:
-		// ok
 	}
-	c.joinRoom(ctx, disp.Room)
+	if !c.joinRoom(ctx, disp.Room) {
+		return // already sent a response
+	}
+	// Publish our own track.
+	if err := c.publishTrack(); err != nil {
+		c.log.Errorw("Cannot publish track", err)
+		c.close(true, callDropped, "publish-failed")
+		return
+	}
+	c.lkRoom.Subscribe()
+	if !pinPrompt {
+		c.log.Infow("Waiting for track subscription(s)")
+		// For dispatches without pin, we first wait for LK participant to become available,
+		// and also for at least one track subscription. In the meantime we keep ringing.
+		if !c.waitSubscribe(ctx) {
+			return // already sent a response
+		}
+		if !acceptCall() {
+			return // already sent a response
+		}
+	}
 	// Wait for the caller to terminate the call.
 	select {
 	case <-ctx.Done():
@@ -404,49 +362,13 @@ func (c *inboundCall) handleInvite(ctx context.Context, req *sip.Request, tx sip
 	}
 }
 
-func (c *inboundCall) sendBye() {
-	if c.inviteReq == nil {
-		return
-	}
-	// This function is for clients, so we need to swap src and dest
-	bye := sip.NewByeRequest(c.inviteReq, c.inviteResp, nil)
-	if contact, ok := c.inviteReq.Contact(); ok {
-		bye.Recipient = &contact.Address
-	} else {
-		bye.Recipient = &c.from.Address
-	}
-	bye.SetSource(c.inviteResp.Source())
-	bye.SetDestination(c.inviteResp.Destination())
-	bye.RemoveHeader("From")
-	bye.AppendHeader((*sip.FromHeader)(c.to))
-	bye.RemoveHeader("To")
-	bye.AppendHeader((*sip.ToHeader)(c.from))
-	if route, ok := bye.RecordRoute(); ok {
-		bye.RemoveHeader("Record-Route")
-		bye.AppendHeader(&sip.RouteHeader{Address: route.Address})
-	}
-	c.inviteReq = nil
-	c.inviteResp = nil
-	tx, err := c.s.sipSrv.TransactionLayer().Request(bye)
-	if err != nil {
-		return
-	}
-	defer tx.Terminate()
-	r, err := sipResponse(tx)
-	if err != nil {
-		return
-	}
-	if r.StatusCode == 200 {
-		_ = c.s.sipSrv.TransportLayer().WriteMsg(sip.NewAckRequest(bye, r, nil))
-	}
-}
-
 func (c *inboundCall) runMediaConn(offerData []byte, conf *config.Config) (answerData []byte, _ error) {
 	mp, err := NewMediaPort(c.log, c.mon, c.s.signalingIp, conf.RTPPort, RoomSampleRate)
 	if err != nil {
 		return nil, err
 	}
 	c.media = mp
+	c.media.EnableTimeout(false) // enabled once we accept the call
 	c.media.SetDTMFAudio(conf.AudioDTMF)
 
 	answerData, mconf, err := mp.SetOffer(offerData)
@@ -469,6 +391,44 @@ func (c *inboundCall) runMediaConn(offerData []byte, conf *config.Config) (answe
 		c.lkRoom.SetDTMFOutput(c.media)
 	}
 	return answerData, nil
+}
+
+func (c *inboundCall) waitMedia(ctx context.Context) bool {
+	// Wait for either a first RTP packet or a predefined delay.
+	//
+	// If the delay kicks in earlier than the caller is ready, they might miss some audio packets.
+	//
+	// On the other hand, if we always wait for RTP, it might be harder to diagnose firewall/routing issues.
+	// In that case both sides will hear nothing, instead of only one side having issues.
+	//
+	// Thus, we wait at most a fixed amount of time before bridging audio.
+
+	delay := time.NewTimer(audioBridgeMaxDelay)
+	defer delay.Stop()
+	select {
+	case <-ctx.Done():
+		c.close(false, CallHangup, "hangup")
+		return false
+	case <-c.media.Timeout():
+		c.closeWithTimeout()
+		return false
+	case <-c.media.Received():
+	case <-delay.C:
+	}
+	return true
+}
+
+func (c *inboundCall) waitSubscribe(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		c.close(false, CallHangup, "hangup")
+		return false
+	case <-c.media.Timeout():
+		c.closeWithTimeout()
+		return false
+	case <-c.lkRoom.Subscribed():
+		return true
+	}
 }
 
 func (c *inboundCall) pinPrompt(ctx context.Context) (disp CallDispatch, _ bool) {
@@ -498,10 +458,10 @@ func (c *inboundCall) pinPrompt(ctx context.Context) (disp CallDispatch, _ bool)
 
 				c.log.Infow("Checking Pin for SIP call", "pin", pin, "noPin", noPin)
 				disp = c.s.handler.DispatchCall(ctx, &CallInfo{
-					ID:         string(c.id),
-					FromUser:   c.from.Address.User,
-					ToUser:     c.to.Address.User,
-					ToHost:     c.to.Address.Host,
+					ID:         string(c.cc.ID()),
+					FromUser:   c.cc.From().User,
+					ToUser:     c.cc.To().User,
+					ToHost:     c.cc.To().Host,
 					SrcAddress: c.src,
 					Pin:        pin,
 					NoPin:      noPin,
@@ -548,12 +508,12 @@ func (c *inboundCall) close(error bool, status CallStatus, reason string) {
 	}
 	defer c.log.Infow("Inbound call closed", "reason", reason)
 	c.closeMedia()
-	c.sendBye()
+	c.cc.Close()
 	if c.callDur != nil {
 		c.callDur()
 	}
 	c.s.cmu.Lock()
-	delete(c.s.activeCalls, c.tag)
+	delete(c.s.activeCalls, c.cc.Tag())
 	c.s.cmu.Unlock()
 	c.cancel()
 }
@@ -603,18 +563,20 @@ func (c *inboundCall) createLiveKitParticipant(ctx context.Context, rconf RoomCo
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (c *inboundCall) publishTrack() error {
 	local, err := c.lkRoom.NewParticipantTrack(RoomSampleRate)
 	if err != nil {
 		_ = c.lkRoom.Close()
 		return err
 	}
 	c.media.WriteAudioTo(local)
-
-	c.lkRoom.Subscribe() // TODO: postpone
 	return nil
 }
 
-func (c *inboundCall) joinRoom(ctx context.Context, rconf RoomConfig) {
+func (c *inboundCall) joinRoom(ctx context.Context, rconf RoomConfig) bool {
 	if c.joinDur != nil {
 		c.joinDur()
 	}
@@ -624,12 +586,13 @@ func (c *inboundCall) joinRoom(ctx context.Context, rconf RoomConfig) {
 		"participant", rconf.Participant.Identity,
 		"participantName", rconf.Participant.Name,
 	)
-	c.log.Infow("Bridging SIP call")
+	c.log.Infow("Joining room")
 	if err := c.createLiveKitParticipant(ctx, rconf); err != nil {
 		c.log.Errorw("Cannot create LiveKit participant", err)
 		c.close(true, callDropped, "participant-failed")
-		return
+		return false
 	}
+	return true
 }
 
 func (c *inboundCall) playAudio(ctx context.Context, frames []media.PCM16Sample) {
@@ -658,5 +621,243 @@ func (c *inboundCall) handleDTMF(tone dtmf.Event) {
 	select {
 	case c.dtmf <- tone:
 	default:
+	}
+}
+
+func (s *Server) newInbound(id LocalTag, invite *sip.Request, inviteTx sip.ServerTransaction) *sipInbound {
+	c := &sipInbound{
+		s:        s,
+		id:       id,
+		invite:   invite,
+		inviteTx: inviteTx,
+	}
+	c.from, _ = invite.From()
+	if c.from != nil {
+		c.tag, _ = getTagFrom(c.from.Params)
+	}
+	c.to, _ = invite.To()
+	return c
+}
+
+type sipInbound struct {
+	s        *Server
+	id       LocalTag
+	tag      RemoteTag
+	invite   *sip.Request
+	inviteTx sip.ServerTransaction
+	from     *sip.FromHeader
+	to       *sip.ToHeader
+
+	mu       sync.RWMutex
+	inviteOk *sip.Response
+	ringing  chan struct{}
+}
+
+func (c *sipInbound) ValidateInvite() error {
+	if c.from == nil {
+		return errors.New("no From header")
+	}
+	if c.to == nil {
+		return errors.New("no To header")
+	}
+	if c.tag == "" {
+		return errors.New("no tag in From")
+	}
+	return nil
+}
+
+func (c *sipInbound) Drop() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.drop()
+}
+
+func (c *sipInbound) drop() {
+	c.stopRinging()
+	if c.inviteTx != nil {
+		c.inviteTx.Terminate()
+	}
+	c.inviteTx = nil
+	c.invite = nil
+	c.inviteOk = nil
+}
+
+func (c *sipInbound) respond(status sip.StatusCode, reason string) {
+	if c.inviteTx == nil {
+		return
+	}
+	_ = c.inviteTx.Respond(sip.NewResponseFromRequest(c.invite, status, reason, nil))
+}
+
+func (c *sipInbound) RespondAndDrop(status sip.StatusCode, reason string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stopRinging()
+	c.respond(status, reason)
+	c.drop()
+}
+
+func (c *sipInbound) From() sip.Uri {
+	if c.from == nil {
+		return sip.Uri{}
+	}
+	return c.from.Address
+}
+
+func (c *sipInbound) To() sip.Uri {
+	if c.to == nil {
+		return sip.Uri{}
+	}
+	return c.to.Address
+}
+
+func (c *sipInbound) ID() LocalTag {
+	return c.id
+}
+
+func (c *sipInbound) Tag() RemoteTag {
+	return c.tag
+}
+
+func (c *sipInbound) RemoteHeaders() Headers {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.invite == nil {
+		return nil
+	}
+	return c.invite.Headers()
+}
+
+func (c *sipInbound) Processing() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.respond(sip.StatusTrying, "Processing")
+}
+
+func (c *sipInbound) sendRinging() {
+	c.respond(sip.StatusRinging, "Ringing")
+}
+
+func (c *sipInbound) attachTag() {
+	// Set the SIP tag for following requests from us to remote (e.g. BYE).
+	c.to.Params["tag"] = string(c.id)
+}
+
+func (c *sipInbound) StartRinging() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.attachTag()
+	c.sendRinging()
+	stop := make(chan struct{})
+	c.ringing = stop
+	go func() {
+		// TODO: check spec for the exact interval
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-ticker.C:
+			}
+			c.mu.Lock()
+			c.sendRinging()
+			c.mu.Unlock()
+		}
+	}()
+}
+
+func (c *sipInbound) stopRinging() {
+	if c.ringing != nil {
+		close(c.ringing)
+		c.ringing = nil
+	}
+}
+
+func (c *sipInbound) Accept(contactHost string, contactPort int, sdpData []byte) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inviteTx == nil {
+		return errors.New("call already rejected")
+	}
+	r := sip.NewResponseFromRequest(c.invite, 200, "OK", sdpData)
+
+	// This will effectively redirect future SIP requests to this server instance (if host address is not LB).
+	r.AppendHeader(&sip.ContactHeader{Address: sip.Uri{Host: contactHost, Port: contactPort}})
+
+	// When behind LB, the source IP may be incorrect and/or the UDP "session" timeout may expire.
+	// This is critical for sending new requests like BYE.
+	//
+	// Thus, instead of relying on LB, we will contact the source IP directly (should be the first Via).
+	// BYE will also copy the same destination address from our response to INVITE.
+	if h, ok := c.invite.Via(); ok && h.Host != "" {
+		port := 5060
+		if h.Port != 0 {
+			port = h.Port
+		}
+		r.SetDestination(fmt.Sprintf("%s:%d", h.Host, port))
+	}
+
+	r.AppendHeader(&contentTypeHeaderSDP)
+	c.stopRinging()
+	if err := c.inviteTx.Respond(r); err != nil {
+		return err
+	}
+	c.inviteOk = r
+	c.inviteTx = nil // accepted
+	return nil
+}
+
+func (c *sipInbound) AcceptBye(req *sip.Request, tx sip.ServerTransaction) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_ = tx.Respond(sip.NewResponseFromRequest(req, 200, "OK", nil))
+	c.drop() // mark as closed
+}
+
+func (c *sipInbound) sendBye() {
+	if c.inviteOk == nil {
+		return // call wasn't established
+	}
+	if c.invite == nil {
+		return // rejected or closed
+	}
+	// This function is for clients, so we need to swap src and dest
+	bye := sip.NewByeRequest(c.invite, c.inviteOk, nil)
+	if contact, ok := c.invite.Contact(); ok {
+		bye.Recipient = &contact.Address
+	} else {
+		bye.Recipient = &c.from.Address
+	}
+	bye.SetSource(c.inviteOk.Source())
+	bye.SetDestination(c.inviteOk.Destination())
+	bye.RemoveHeader("From")
+	bye.AppendHeader((*sip.FromHeader)(c.to))
+	bye.RemoveHeader("To")
+	bye.AppendHeader((*sip.ToHeader)(c.from))
+	if route, ok := bye.RecordRoute(); ok {
+		bye.RemoveHeader("Record-Route")
+		bye.AppendHeader(&sip.RouteHeader{Address: route.Address})
+	}
+	c.drop()
+	sendBye(c, bye)
+}
+
+func (c *sipInbound) WriteRequest(req *sip.Request) error {
+	return c.s.sipSrv.TransportLayer().WriteMsg(req)
+}
+
+func (c *sipInbound) Transaction(req *sip.Request) (sip.ClientTransaction, error) {
+	return c.s.sipSrv.TransactionLayer().Request(req)
+}
+
+// Close the inbound call cleanly. Depending on the call state it will either send BYE or just terminate INVITE.
+func (c *sipInbound) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.inviteOk != nil {
+		c.sendBye()
+	} else {
+		c.drop()
 	}
 }

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -76,6 +76,10 @@ type MediaPort struct {
 	dtmfIn         atomic.Pointer[func(ev dtmf.Event)]
 }
 
+func (p *MediaPort) EnableTimeout(enabled bool) {
+	p.conn.EnableTimeout(enabled)
+}
+
 func (p *MediaPort) Close() {
 	if !p.closed.CompareAndSwap(false, true) {
 		return

--- a/pkg/sip/protocol.go
+++ b/pkg/sip/protocol.go
@@ -1,0 +1,61 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sip
+
+import (
+	"fmt"
+
+	"github.com/emiago/sipgo/sip"
+)
+
+type ErrorStatus struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *ErrorStatus) Error() string {
+	if e.Message != "" {
+		return fmt.Sprintf("sip status: %d: %s", e.StatusCode, e.Message)
+	}
+	return fmt.Sprintf("sip status: %d", e.StatusCode)
+}
+
+type Signaling interface {
+	From() sip.Uri
+	To() sip.Uri
+	ID() LocalTag
+	Tag() RemoteTag
+	RemoteHeaders() Headers
+
+	WriteRequest(req *sip.Request) error
+	Transaction(req *sip.Request) (sip.ClientTransaction, error)
+
+	Drop()
+}
+
+func sendBye(c Signaling, bye *sip.Request) {
+	tx, err := c.Transaction(bye)
+	if err != nil {
+		return
+	}
+	defer tx.Terminate()
+	r, err := sipResponse(tx)
+	if err != nil {
+		return
+	}
+	if r.StatusCode == 200 {
+		_ = c.WriteRequest(sip.NewAckRequest(bye, r, nil))
+	}
+}

--- a/pkg/sip/server.go
+++ b/pkg/sip/server.go
@@ -51,6 +51,21 @@ type CallInfo struct {
 	NoPin      bool
 }
 
+type AuthResult int
+
+const (
+	AuthNotFound = AuthResult(iota)
+	AuthDrop
+	AuthPassword
+	AuthAccept
+)
+
+type AuthInfo struct {
+	Result   AuthResult
+	Username string
+	Password string
+}
+
 type DispatchResult int
 
 const (
@@ -68,7 +83,7 @@ type CallDispatch struct {
 }
 
 type Handler interface {
-	GetAuthCredentials(ctx context.Context, fromUser, toUser, toHost, srcAddress string) (username, password string, drop bool, err error)
+	GetAuthCredentials(ctx context.Context, fromUser, toUser, toHost, srcAddress string) (AuthInfo, error)
 	DispatchCall(ctx context.Context, info *CallInfo) CallDispatch
 }
 
@@ -114,10 +129,6 @@ func NewServer(conf *config.Config, log logger.Logger, mon *stats.Monitor) *Serv
 
 func (s *Server) SetHandler(handler Handler) {
 	s.handler = handler
-}
-
-func sipErrorResponse(tx sip.ServerTransaction, req *sip.Request) {
-	_ = tx.Respond(sip.NewResponseFromRequest(req, 400, "", nil))
 }
 
 func (s *Server) startUDP() error {

--- a/pkg/sip/types.go
+++ b/pkg/sip/types.go
@@ -16,9 +16,89 @@ package sip
 
 import (
 	"errors"
+	"net"
+	"net/netip"
+	"strconv"
 
 	"github.com/emiago/sipgo/sip"
+	"github.com/livekit/protocol/logger"
 )
+
+type Headers []sip.Header
+
+func (h Headers) GetHeader(name string) sip.Header {
+	name = sip.HeaderToLower(name)
+	for _, kv := range h {
+		if sip.HeaderToLower(kv.Name()) == name {
+			return kv
+		}
+	}
+	return nil
+}
+
+type URI struct {
+	User string
+	Host string
+	Addr netip.AddrPort
+}
+
+func (u URI) Normalize() URI {
+	if addr, sport, err := net.SplitHostPort(u.Host); err == nil {
+		if port, err := strconv.Atoi(sport); err == nil {
+			u.Host = addr
+			u.Addr = netip.AddrPortFrom(u.Addr.Addr(), uint16(port))
+		}
+	}
+	return u
+}
+
+func (u URI) GetHost() string {
+	host := u.Host
+	if host == "" {
+		host = u.Addr.Addr().String()
+	}
+	return host
+}
+
+func (u URI) GetPort() int {
+	port := int(u.Addr.Port())
+	if port == 0 {
+		port = 5060
+	}
+	return port
+}
+
+func (u URI) GetPortOrNone() int {
+	port := u.GetPort()
+	if port == 5060 {
+		port = 0
+	}
+	return port
+}
+
+func (u URI) GetHostPort() string {
+	return u.GetHost() + ":" + strconv.Itoa(u.GetPort())
+}
+
+func (u URI) GetDest() string {
+	host := u.Host
+	if u.Addr.Addr().IsValid() {
+		host = u.Addr.Addr().String()
+	}
+	host += ":" + strconv.Itoa(u.GetPort())
+	return host
+}
+
+func (u URI) GetURI() *sip.Uri {
+	su := &sip.Uri{
+		User: u.User,
+		Host: u.GetHost(),
+	}
+	if port := u.Addr.Port(); port != 0 {
+		su.Port = int(port)
+	}
+	return su
+}
 
 type LocalTag string
 type RemoteTag string
@@ -28,7 +108,11 @@ func getFromTag(r *sip.Request) (RemoteTag, error) {
 	if !ok {
 		return "", errors.New("no From on Request")
 	}
-	return getTagFrom(from.Params)
+	tag, ok := getTagFrom(from.Params)
+	if !ok {
+		return "", errors.New("no tag in From on Request")
+	}
+	return tag, nil
 }
 
 func getToTag(r *sip.Response) (RemoteTag, error) {
@@ -36,13 +120,53 @@ func getToTag(r *sip.Response) (RemoteTag, error) {
 	if !ok {
 		return "", errors.New("no To on Response")
 	}
-	return getTagFrom(to.Params)
+	tag, ok := getTagFrom(to.Params)
+	if !ok {
+		return "", errors.New("no tag in To on Response")
+	}
+	return tag, nil
 }
 
-func getTagFrom(params sip.HeaderParams) (RemoteTag, error) {
+func getTagFrom(params sip.HeaderParams) (RemoteTag, bool) {
 	tag, ok := params["tag"]
 	if !ok {
-		return "", errors.New("no tag on the address")
+		return "", false
 	}
-	return RemoteTag(tag), nil
+	return RemoteTag(tag), true
+}
+
+func LoggerWithParams(log logger.Logger, c Signaling) logger.Logger {
+	if a := c.From(); a.Host != "" {
+		log = log.WithValues("fromHost", a.Host, "fromUser", a.User)
+	}
+	if a := c.To(); a.Host != "" {
+		log = log.WithValues("toHost", a.Host, "toUser", a.User)
+	}
+	if tag := c.Tag(); tag != "" {
+		log = log.WithValues("sipTag", tag)
+	}
+	return log
+}
+
+func LoggerWithHeaders(log logger.Logger, c Signaling) logger.Logger {
+	headers := c.RemoteHeaders()
+	for hdr, name := range headerToLog {
+		if h := headers.GetHeader(hdr); h != nil {
+			log = log.WithValues(name, h.Value())
+		}
+	}
+	return log
+}
+
+func HeadersToAttrs(attrs map[string]string, c Signaling) map[string]string {
+	if attrs == nil {
+		attrs = make(map[string]string)
+	}
+	headers := c.RemoteHeaders()
+	for hdr, name := range headerToAttr {
+		if h := headers.GetHeader(hdr); h != nil {
+			attrs[name] = h.Value()
+		}
+	}
+	return attrs
 }


### PR DESCRIPTION
Refactor SIP signaling an change the call flow for both inbound and outbound.

For inbound **with PIN** (almost the same as before):
- Keep sending Ringing status for the whole time until the call is accepted.
- Signal to SIP peer as soon as we can and run the audio for the pin prompts.
- Given the PIN, join selected room on LK server.
- Immediate publish SIP track and subscribe to the rest.

For inbound **without PIN**:
- Keep sending Ringing status for the whole time until the call is accepted.
- First connect to the LK room according to dispatch rules.
- Subscribe and wait for at least one audio track. This is important! SIP now **keeps ringing** until there's one other participant with enabled audio track.
- Accept the call on SIP side. Wait for the first media packet.
- Publish SIP track to LiveKit.

For outbound:
- Flow as before, but delay track subscription until media pipeline is initialized.

Should resolve #102, #136, #114 