### PR TITLE
Adjust some spammy log levels

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -346,7 +346,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, req *sip.Request, tx sip
 
 	res.AppendHeader(&contentTypeHeaderSDP)
 	if err = tx.Respond(res); err != nil {
-		c.log.Errorw("Cannot respond to INVITE", err)
+		c.log.Infow("Cannot respond to INVITE", "error", err)
 		return
 	}
 	c.inviteReq = req

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -141,7 +141,7 @@ func (p *MediaPort) decodeSDP(data []byte) (*sdp.SessionDescription, *MediaConf,
 	}
 	c, err := sdpGetAudioCodec(desc)
 	if err != nil {
-		p.log.Errorw("SIP SDP failed", err)
+		p.log.Infow("SIP SDP failed", "error", err)
 		return nil, nil, err
 	}
 	return desc, c, nil

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -260,7 +260,7 @@ func sipResponse(tx sip.ClientTransaction) (*sip.Response, error) {
 func (c *outboundCall) stopSIP(reason string) {
 	if c.sipInviteReq != nil {
 		if err := c.sipBye(); err != nil {
-			c.log.Infow("SIP bye failed", err)
+			c.log.Infow("SIP bye failed", "error", err)
 		}
 		c.mon.CallTerminate(reason)
 	}
@@ -294,14 +294,14 @@ func (c *outboundCall) sipSignal(conf sipOutboundConfig) error {
 		}
 	}
 	if err != nil {
-		c.log.Infow("SIP invite failed", err)
+		c.log.Infow("SIP invite failed", "error", err)
 		return err // TODO: should we retry? maybe new offer will work
 	}
 	c.sipInviteReq, c.sipInviteResp = inviteReq, inviteResp
 
 	err = c.sipAccept(inviteReq, inviteResp)
 	if err != nil {
-		c.log.Infow("SIP accept failed", err)
+		c.log.Infow("SIP accept failed", "error", err)
 		return err
 	}
 	if err := c.media.SetAnswer(c.sipInviteResp.Body()); err != nil {

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -97,7 +97,7 @@ func (c *outboundCall) Start(ctx context.Context) {
 	defer c.mon.CallEnd()
 	err := c.ConnectSIP(ctx)
 	if err != nil {
-		c.log.Errorw("SIP call failed", err)
+		c.log.Infow("SIP call failed", "error", err)
 		c.CloseWithReason(callDropped, "connect error")
 		return
 	}
@@ -260,7 +260,7 @@ func sipResponse(tx sip.ClientTransaction) (*sip.Response, error) {
 func (c *outboundCall) stopSIP(reason string) {
 	if c.sipInviteReq != nil {
 		if err := c.sipBye(); err != nil {
-			c.log.Errorw("SIP bye failed", err)
+			c.log.Infow("SIP bye failed", err)
 		}
 		c.mon.CallTerminate(reason)
 	}
@@ -294,14 +294,14 @@ func (c *outboundCall) sipSignal(conf sipOutboundConfig) error {
 		}
 	}
 	if err != nil {
-		c.log.Errorw("SIP invite failed", err)
+		c.log.Infow("SIP invite failed", err)
 		return err // TODO: should we retry? maybe new offer will work
 	}
 	c.sipInviteReq, c.sipInviteResp = inviteReq, inviteResp
 
 	err = c.sipAccept(inviteReq, inviteResp)
 	if err != nil {
-		c.log.Errorw("SIP accept failed", err)
+		c.log.Infow("SIP accept failed", err)
 		return err
 	}
 	if err := c.media.SetAnswer(c.sipInviteResp.Body()); err != nil {


### PR DESCRIPTION
Do not log errors triggered by bad user configuration, or connectivity issue with a SIP endpoint as Error.