### PR TITLE
When a Refer succeeds, give time for the peer to hang up first, but hang up ourselves if this doesn't happen within 1 second

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -748,8 +748,8 @@ func (c *inboundCall) transferCall(ctx context.Context, transferTo string) error
 
 	c.log.Infow("inbound call tranferred", "transferTo", transferTo)
 
-	// This is needed to actually terminate the session before a media timeout
-	c.Close()
+	// Give time for the peer to hang up first, but hang up ourselves if this doesn't happen within 1 second
+	time.AfterFunc(referByeTimeout, func() { c.Close() })
 
 	return nil
 

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -406,10 +406,10 @@ func (c *outboundCall) transferCall(ctx context.Context, transferTo string) erro
 		return err
 	}
 
-	c.log.Infow("outbound l tranferred", "transferTo", transferTo)
+	c.log.Infow("outbound call tranferred", "transferTo", transferTo)
 
-	// This is needed to actually terminate the session before a media timeout
-	c.CloseWithReason(CallHangup, "call transferred")
+	// Give time for the peer to hang up first, but hang up ourselves if this doesn't happen within 1 second
+	time.AfterFunc(referByeTimeout, func() { c.CloseWithReason(CallHangup, "call transferred") })
 
 	return nil
 }

--- a/pkg/sip/protocol.go
+++ b/pkg/sip/protocol.go
@@ -28,6 +28,7 @@ import (
 
 const (
 	notifyAckTimeout = 5 * time.Second
+	referByeTimeout  = time.Second
 )
 
 var (


### PR DESCRIPTION
Some SIP peers hang up immediately while some expect us to hang up first