### PR TITLE
Always set contact header for outbound to IP.

### DIFF
--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -16,6 +16,7 @@ package sip
 
 import (
 	"context"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,7 +34,7 @@ import (
 )
 
 type MediaConfig struct {
-	IP                  string
+	IP                  netip.Addr
 	Ports               rtcconfig.PortRange
 	MediaTimeoutInitial time.Duration
 	MediaTimeout        time.Duration
@@ -71,7 +72,7 @@ func NewMediaPortWith(log logger.Logger, mon *stats.CallMonitor, conn rtp.UDPCon
 type MediaPort struct {
 	log              logger.Logger
 	mon              *stats.CallMonitor
-	externalIP       string
+	externalIP       netip.Addr
 	conn             *rtp.Conn
 	mediaTimeout     <-chan struct{}
 	dtmfAudioEnabled bool

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"net/netip"
 	"slices"
 	"strconv"
 	"strings"
@@ -111,6 +112,14 @@ func PrintAudioInWriter(p *MediaPort) string {
 	return p.audioInHandler.(fmt.Stringer).String()
 }
 
+func newIP(v string) netip.Addr {
+	ip, err := netip.ParseAddr(v)
+	if err != nil {
+		panic(err)
+	}
+	return ip
+}
+
 func TestMediaPort(t *testing.T) {
 	codecs := media.Codecs()
 	disableAll := func() {
@@ -151,14 +160,14 @@ func TestMediaPort(t *testing.T) {
 					log := logger.GetLogger()
 
 					m1, err := NewMediaPortWith(log.WithName("one"), nil, c1, &MediaConfig{
-						IP:    "1.1.1.1",
+						IP:    newIP("1.1.1.1"),
 						Ports: rtcconfig.PortRange{Start: 10000},
 					}, rate)
 					require.NoError(t, err)
 					defer m1.Close()
 
 					m2, err := NewMediaPortWith(log.WithName("two"), nil, c2, &MediaConfig{
-						IP:    "2.2.2.2",
+						IP:    newIP("2.2.2.2"),
 						Ports: rtcconfig.PortRange{Start: 20000},
 					}, rate)
 					require.NoError(t, err)

--- a/pkg/sip/server.go
+++ b/pkg/sip/server.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
+
 	"github.com/livekit/sip/pkg/media"
 
 	"github.com/livekit/sip/pkg/config"
@@ -110,8 +111,8 @@ type Server struct {
 	sipConnUDP       *net.UDPConn
 	sipConnTCP       *net.TCPListener
 	sipUnhandled     RequestHandler
-	signalingIp      string
-	signalingIpLocal string
+	signalingIp      netip.Addr
+	signalingIpLocal netip.Addr
 
 	inProgressInvites []*inProgressInvite
 
@@ -208,7 +209,11 @@ func (s *Server) Start(agent *sipgo.UserAgent, unhandled RequestHandler) error {
 			return err
 		}
 	} else if s.conf.NAT1To1IP != "" {
-		s.signalingIp = s.conf.NAT1To1IP
+		ip, err := netip.ParseAddr(s.conf.NAT1To1IP)
+		if err != nil {
+			return err
+		}
+		s.signalingIp = ip
 		s.signalingIpLocal = s.signalingIp
 	} else {
 		if s.signalingIp, err = getLocalIP(s.conf.LocalNet); err != nil {

--- a/pkg/sip/signaling.go
+++ b/pkg/sip/signaling.go
@@ -147,7 +147,7 @@ func sdpAnswerMediaDesc(rtpListenerPort int, res *MediaConf) []*sdp.MediaDescrip
 	}
 }
 
-func sdpGenerateOffer(publicIp string, rtpListenerPort int) ([]byte, error) {
+func sdpGenerateOffer(publicIp netip.Addr, rtpListenerPort int) ([]byte, error) {
 	sessId := rand.Uint64() // TODO: do we need to track these?
 
 	mediaDesc := sdpMediaOffer(rtpListenerPort)
@@ -159,13 +159,13 @@ func sdpGenerateOffer(publicIp string, rtpListenerPort int) ([]byte, error) {
 			SessionVersion: sessId,
 			NetworkType:    "IN",
 			AddressType:    "IP4",
-			UnicastAddress: publicIp,
+			UnicastAddress: publicIp.String(),
 		},
 		SessionName: "LiveKit",
 		ConnectionInformation: &sdp.ConnectionInformation{
 			NetworkType: "IN",
 			AddressType: "IP4",
-			Address:     &sdp.Address{Address: publicIp},
+			Address:     &sdp.Address{Address: publicIp.String()},
 		},
 		TimeDescriptions: []sdp.TimeDescription{
 			{
@@ -182,7 +182,7 @@ func sdpGenerateOffer(publicIp string, rtpListenerPort int) ([]byte, error) {
 	return data, err
 }
 
-func sdpGenerateAnswer(offer *sdp.SessionDescription, publicIp string, rtpListenerPort int, res *MediaConf) ([]byte, error) {
+func sdpGenerateAnswer(offer *sdp.SessionDescription, publicIp netip.Addr, rtpListenerPort int, res *MediaConf) ([]byte, error) {
 	answer := sdp.SessionDescription{
 		Version: 0,
 		Origin: sdp.Origin{
@@ -191,13 +191,13 @@ func sdpGenerateAnswer(offer *sdp.SessionDescription, publicIp string, rtpListen
 			SessionVersion: offer.Origin.SessionID + 2,
 			NetworkType:    "IN",
 			AddressType:    "IP4",
-			UnicastAddress: publicIp,
+			UnicastAddress: publicIp.String(),
 		},
 		SessionName: "LiveKit",
 		ConnectionInformation: &sdp.ConnectionInformation{
 			NetworkType: "IN",
 			AddressType: "IP4",
-			Address:     &sdp.Address{Address: publicIp},
+			Address:     &sdp.Address{Address: publicIp.String()},
 		},
 		TimeDescriptions: []sdp.TimeDescription{
 			{

--- a/pkg/sip/types.go
+++ b/pkg/sip/types.go
@@ -100,6 +100,17 @@ func (u URI) GetURI() *sip.Uri {
 	return su
 }
 
+func (u URI) GetContactURI() *sip.Uri {
+	su := &sip.Uri{
+		User: u.User,
+		Host: u.Addr.Addr().String(),
+	}
+	if port := u.Addr.Port(); port != 0 {
+		su.Port = int(port)
+	}
+	return su
+}
+
 type LocalTag string
 type RemoteTag string
 

--- a/test/integration/sip_test.go
+++ b/test/integration/sip_test.go
@@ -66,7 +66,7 @@ func runSIPServer(t testing.TB, lk *LiveKit) *SIPServer {
 		Redis:             lk.Redis,
 		SIPPort:           sipPort,
 		SIPPortListen:     sipPort,
-		ListenIP:          local,
+		ListenIP:          local.String(),
 		RTPPort:           rtcconfig.PortRange{Start: 20000, End: 20010},
 		UseExternalIP:     false,
 		MaxCpuUtilization: 0.9,


### PR DESCRIPTION
Always set contact header for outbound to IP address instead of the hostname. Also, refactor the code to use `netip.Addr` and `netip.AddrPort`.