### PR TITLE
Update Redis Configuration and Add Dependency Management in docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,8 @@ services:
     image: redis
     volumes:
       - redis_data:/data
-    expose:
-      - 6379
+    ports:
+      - 6379:6379
     # The following line might be uncommented to run on MacOS
     # for testing and development purposes only.
     # network_mode: host
@@ -12,6 +12,9 @@ services:
     image: livekit/livekit-server
     command: --dev --redis-host localhost:6379
     network_mode: host
+    depends_on:
+        redis:
+            condition: service_started
   sip:
     image: livekit/sip
     network_mode: host


### PR DESCRIPTION
This MR makes the following updates to the `docker-compose.yml` file:  

1. **Redis Port Configuration:**
   - Removed the deprecated  `expose` directive for Redis and changed for `ports` directive.

2. **Livekit Server Improvements:**
   - Added a `depends_on` directive for the `livekit` service to ensure it starts only after the `redis` service is up and running.  
   - Introduced a `condition: service_started` to improve service reliability during startup.

These changes enhance service dependencies and improve Redis accessibility, especially for local development and testing environments.

Tested with Docker version 27.4.1