### PR TITLE
Remove actions/cache usage in workflows/build.yaml

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,14 +28,5 @@ jobs:
         with:
           lfs: true
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: sip-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            sip-
-
       - name: Build docker image
         run: docker build -t sip -f ./build/sip/Dockerfile .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,10 +31,8 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
+            ~/.cache/go-build
             ~/go/pkg/mod
-            ~/go/bin
-            ~/bin/protoc
-            ~/.cache
           key: sip-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             sip-

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
             ~/.cache
           key: sip-${{ hashFiles('**/go.sum') }}
           restore-keys: |
-            ${{ runner.os }}-sip-
+            sip-
 
       - name: Build docker image
         run: docker build -t sip -f ./build/sip/Dockerfile .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,9 @@ jobs:
             ~/go/bin
             ~/bin/protoc
             ~/.cache
-          key: sip
+          key: sip-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-sip-
 
       - name: Build docker image
         run: docker build -t sip -f ./build/sip/Dockerfile .


### PR DESCRIPTION
No cache is being saved here currently, below messages are logged in workflow executions e.g. https://github.com/livekit/sip/actions/runs/13057592439/job/36432439669#step:3:14

> Cache not found for input keys: sip

and https://github.com/livekit/sip/actions/runs/13057592439/job/36432439669#step:7:2

> Warning: Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.

As such, the usage of actions/cache here is not really doing anything - proposing removing.

Modifying the usage of actions/cache a bit following https://github.com/actions/cache/blob/main/examples.md#go---modules does not resolve these messages, the workflow would need to additionally - or instead - utilize https://github.com/actions/setup-go?tab=readme-ov-file#caching-dependency-files-and-build-outputs