### PR TITLE
fix: prevent log resolver panic

### DIFF
--- a/pkg/sip/room.go
+++ b/pkg/sip/room.go
@@ -84,7 +84,11 @@ func NewRoom(log logger.Logger) *Room {
 	go func() {
 		select {
 		case <-r.ready.Watch():
-			resolve("room", r.room.Name(), "roomID", r.room.SID())
+			if r.room != nil {
+				resolve("room", r.room.Name(), "roomID", r.room.SID())
+			} else {
+				resolve()
+			}
 		case <-r.stopped.Watch():
 			resolve()
 		case <-r.closed.Watch():


### PR DESCRIPTION
If the room is closed quickly after connect, we could end up with a nil `r.room`.