### PR TITLE
Fix memory leak in resampler

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,8 +37,8 @@ jobs:
         with:
           go-version: ">=1.24.1"
 
-      - name: Set up gotestfmt
-        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@v2.5.0
+      - name: Set up tparse
+        run: go install github.com/mfridman/tparse@v0.17.0
 
       - name: Static Check
         uses: dominikh/staticcheck-action@v1
@@ -50,7 +50,7 @@ jobs:
       - name: Test
         run: |
           set -euo pipefail
-          go test -coverpkg=./... -race -json -v -coverprofile=coverage.out -covermode=atomic ./pkg/... 2>&1 | tee /tmp/gotest.log | gotestfmt
+          go test -coverpkg=./... -race -json -v -coverprofile=coverage.out -covermode=atomic ./pkg/... 2>&1 | tee /tmp/gotest.log | tparse
 
       - name: Pull LiveKit Docker image
         run: |
@@ -60,7 +60,7 @@ jobs:
       - name: Test E2E
         run: |
           set -euo pipefail
-          go test -coverpkg=./... -json -v -coverprofile=coverage2.out -covermode=atomic ./test/integration/... 2>&1 | tee -a /tmp/gotest.log | gotestfmt
+          go test -coverpkg=./... -json -v -coverprofile=coverage2.out -covermode=atomic ./test/integration/... 2>&1 | tee -a /tmp/gotest.log | tparse
 
       - name: Upload test log
         uses: actions/upload-artifact@v4

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,6 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.10.0
 	github.com/urfave/cli/v2 v2.27.2
-	github.com/zaf/resample v1.5.0
 	golang.org/x/exp v0.0.0-20250207012021-f9890c6ad9f3
 	google.golang.org/protobuf v1.36.5
 	gopkg.in/hraban/opus.v2 v2.0.0-20230925203106-0188a62cb302

--- a/go.sum
+++ b/go.sum
@@ -260,8 +260,6 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBi
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/zaf/resample v1.5.0 h1:c3yumHrV1cJoED8ZY2Ai3cehS8s0mJSroA9/vMaUcho=
-github.com/zaf/resample v1.5.0/go.mod h1:e4yWalfgRccQrnZSrkIxTqmMCOPhTi1xvYpNpRIB13k=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=


### PR DESCRIPTION
Fix memory leak in resampler. While at it, optimize it for (almost) zero copy.

SIP now includes bindings for Soxr resampler instead of using a third-party library. Leak is _not_ caused by the library, to be clear.

Binding directly to Soxr makes it easier to use automatic cleanup function and avoid copying and reformatting the data, which also reduces GC pressure and CPU cycles.

This change also adds a test to avoid resampler memory leaks in the future.