### PR TITLE
Support media-level c= fallback to session-level connection in SDP parsing

### DIFF
--- a/pkg/media/sdp/helpers.go
+++ b/pkg/media/sdp/helpers.go
@@ -29,14 +29,22 @@ func GetAudio(s *sdp.SessionDescription) *sdp.MediaDescription {
 	return nil
 }
 
+// GetAudioDest returns the RTP dst address:port for an audio m=
+// it first uses media-level c=, then session-level c=.
 func GetAudioDest(s *sdp.SessionDescription, audio *sdp.MediaDescription) netip.AddrPort {
 	if audio == nil || s == nil {
 		return netip.AddrPort{}
 	}
-	ci := s.ConnectionInformation
+
+	// pick media-level c=; if absent, fall back to session-level c=
+	ci := audio.ConnectionInformation
+	if ci == nil {
+		ci = s.ConnectionInformation
+	}
 	if ci == nil || ci.NetworkType != "IN" {
 		return netip.AddrPort{}
 	}
+
 	ip, err := netip.ParseAddr(ci.Address.Address)
 	if err != nil {
 		return netip.AddrPort{}

--- a/pkg/media/sdp/helpers.go
+++ b/pkg/media/sdp/helpers.go
@@ -15,6 +15,8 @@
 package sdp
 
 import (
+	"errors"
+	"fmt"
 	"net/netip"
 
 	"github.com/pion/sdp/v3"
@@ -31,9 +33,9 @@ func GetAudio(s *sdp.SessionDescription) *sdp.MediaDescription {
 
 // GetAudioDest returns the RTP dst address:port for an audio m=
 // it first uses media-level c=, then session-level c=.
-func GetAudioDest(s *sdp.SessionDescription, audio *sdp.MediaDescription) netip.AddrPort {
+func GetAudioDest(s *sdp.SessionDescription, audio *sdp.MediaDescription) (netip.AddrPort, error) {
 	if audio == nil || s == nil {
-		return netip.AddrPort{}
+		return netip.AddrPort{}, errors.New("no audio in sdp")
 	}
 
 	// pick media-level c=; if absent, fall back to session-level c=
@@ -41,12 +43,18 @@ func GetAudioDest(s *sdp.SessionDescription, audio *sdp.MediaDescription) netip.
 	if ci == nil {
 		ci = s.ConnectionInformation
 	}
-	if ci == nil || ci.NetworkType != "IN" {
-		return netip.AddrPort{}
+	var addr string
+	if ci != nil && ci.NetworkType == "IN" {
+		addr = ci.Address.Address
+	} else if s.Origin.NetworkType == "IN" {
+		addr = s.Origin.UnicastAddress
 	}
-	ip, err := netip.ParseAddr(ci.Address.Address)
+	if addr == "" {
+		return netip.AddrPort{}, errors.New("no destination address in sdp")
+	}
+	ip, err := netip.ParseAddr(addr)
 	if err != nil {
-		return netip.AddrPort{}
+		return netip.AddrPort{}, fmt.Errorf("invalid destination address %q: %w", addr, err)
 	}
-	return netip.AddrPortFrom(ip, uint16(audio.MediaName.Port.Value))
+	return netip.AddrPortFrom(ip, uint16(audio.MediaName.Port.Value)), nil
 }

--- a/pkg/media/sdp/helpers.go
+++ b/pkg/media/sdp/helpers.go
@@ -44,7 +44,6 @@ func GetAudioDest(s *sdp.SessionDescription, audio *sdp.MediaDescription) netip.
 	if ci == nil || ci.NetworkType != "IN" {
 		return netip.AddrPort{}
 	}
-
 	ip, err := netip.ParseAddr(ci.Address.Address)
 	if err != nil {
 		return netip.AddrPort{}

--- a/pkg/media/sdp/helpers_test.go
+++ b/pkg/media/sdp/helpers_test.go
@@ -1,0 +1,107 @@
+// Copyright 2024 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdp
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/pion/sdp/v3"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAudioDest(t *testing.T) {
+	tests := []struct {
+		name     string
+		session  *sdp.SessionDescription
+		audio    *sdp.MediaDescription
+		expected netip.AddrPort
+	}{
+		{
+			name: "media level connection info",
+			session: &sdp.SessionDescription{
+				MediaDescriptions: []*sdp.MediaDescription{
+					{
+						MediaName: sdp.MediaName{
+							Media: "audio",
+							Port:  sdp.RangedPort{Value: 1234},
+						},
+						ConnectionInformation: &sdp.ConnectionInformation{
+							NetworkType: "IN",
+							AddressType: "IP4",
+							Address:     &sdp.Address{Address: "1.2.3.4"},
+						},
+					},
+				},
+			},
+			audio: &sdp.MediaDescription{
+				MediaName: sdp.MediaName{
+					Media: "audio",
+					Port:  sdp.RangedPort{Value: 1234},
+				},
+				ConnectionInformation: &sdp.ConnectionInformation{
+					NetworkType: "IN",
+					AddressType: "IP4",
+					Address:     &sdp.Address{Address: "1.2.3.4"},
+				},
+			},
+			expected: netip.MustParseAddrPort("1.2.3.4:1234"),
+		},
+		{
+			name: "session level connection info",
+			session: &sdp.SessionDescription{
+				ConnectionInformation: &sdp.ConnectionInformation{
+					NetworkType: "IN",
+					AddressType: "IP4",
+					Address:     &sdp.Address{Address: "1.2.3.4"},
+				},
+				MediaDescriptions: []*sdp.MediaDescription{
+					{
+						MediaName: sdp.MediaName{
+							Media: "audio",
+							Port:  sdp.RangedPort{Value: 1234},
+						},
+					},
+				},
+			},
+			audio: &sdp.MediaDescription{
+				MediaName: sdp.MediaName{
+					Media: "audio",
+					Port:  sdp.RangedPort{Value: 1234},
+				},
+			},
+			expected: netip.MustParseAddrPort("1.2.3.4:1234"),
+		},
+		{
+			name:     "nil session",
+			session:  nil,
+			audio:    &sdp.MediaDescription{},
+			expected: netip.AddrPort{},
+		},
+		{
+			name:     "nil audio",
+			session:  &sdp.SessionDescription{},
+			audio:    nil,
+			expected: netip.AddrPort{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := GetAudioDest(test.session, test.audio)
+			require.Equal(t, test.expected, got)
+		})
+	}
+}

--- a/pkg/media/sdp/helpers_test.go
+++ b/pkg/media/sdp/helpers_test.go
@@ -28,6 +28,7 @@ func TestGetAudioDest(t *testing.T) {
 		session  *sdp.SessionDescription
 		audio    *sdp.MediaDescription
 		expected netip.AddrPort
+		error    bool
 	}{
 		{
 			name: "media level connection info",
@@ -37,11 +38,6 @@ func TestGetAudioDest(t *testing.T) {
 						MediaName: sdp.MediaName{
 							Media: "audio",
 							Port:  sdp.RangedPort{Value: 1234},
-						},
-						ConnectionInformation: &sdp.ConnectionInformation{
-							NetworkType: "IN",
-							AddressType: "IP4",
-							Address:     &sdp.Address{Address: "1.2.3.4"},
 						},
 					},
 				},
@@ -89,18 +85,25 @@ func TestGetAudioDest(t *testing.T) {
 			session:  nil,
 			audio:    &sdp.MediaDescription{},
 			expected: netip.AddrPort{},
+			error:    true,
 		},
 		{
 			name:     "nil audio",
 			session:  &sdp.SessionDescription{},
 			audio:    nil,
 			expected: netip.AddrPort{},
+			error:    true,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := GetAudioDest(test.session, test.audio)
+			got, err := GetAudioDest(test.session, test.audio)
+			if test.error {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
 			require.Equal(t, test.expected, got)
 		})
 	}

--- a/pkg/media/sdp/offer.go
+++ b/pkg/media/sdp/offer.go
@@ -352,8 +352,11 @@ func Parse(data []byte) (*Description, error) {
 	if audio == nil {
 		return nil, errors.New("no audio in sdp")
 	}
-	offer.Addr = GetAudioDest(&offer.SDP, audio)
-	if !offer.Addr.IsValid() {
+	var err error
+	offer.Addr, err = GetAudioDest(&offer.SDP, audio)
+	if err != nil {
+		return nil, err
+	} else if !offer.Addr.IsValid() || offer.Addr.Port() == 0 {
 		return nil, fmt.Errorf("invalid audio address %q", offer.Addr)
 	}
 	m, err := ParseMedia(audio)

--- a/pkg/media/sdp/offer.go
+++ b/pkg/media/sdp/offer.go
@@ -353,6 +353,9 @@ func Parse(data []byte) (*Description, error) {
 		return nil, errors.New("no audio in sdp")
 	}
 	offer.Addr = GetAudioDest(&offer.SDP, audio)
+	if !offer.Addr.IsValid() {
+		return nil, fmt.Errorf("invalid audio address %q", offer.Addr)
+	}
 	m, err := ParseMedia(audio)
 	if err != nil {
 		return nil, err

--- a/pkg/media/sdp/offer_test.go
+++ b/pkg/media/sdp/offer_test.go
@@ -339,6 +339,78 @@ func TestSDPMediaAnswer(t *testing.T) {
 	}, offer)
 }
 
+func TestParseOffer(t *testing.T) {
+	tests := []struct {
+		name    string
+		sdp     string
+		wantErr bool
+	}{
+		{
+			name: "media level c= only",
+			sdp: `v=0
+o=Test 1 1 IN IP4 127.0.0.1
+s=Stream1
+t=0 0
+m=audio 59236 RTP/AVP 0 101
+c=IN IP4 127.0.0.1
+a=rtpmap:0 PCMU/8000
+a=rtpmap:101 telephone-event/8000
+a=sendrecv
+a=rtcp:59237
+a=ptime:20
+`,
+			wantErr: false,
+		},
+		{
+			name: "invalid network type",
+			sdp: `v=0
+o=- 1234567890 1234567890 IN IP4 1.2.3.4
+s=LiveKit
+c=FOO IP4 1.2.3.4
+t=0 0
+m=audio 1234 RTP/AVP 9 0 8 101
+a=rtpmap:9 G722/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-16
+a=ptime:20
+a=sendrecv
+`,
+			wantErr: true,
+		},
+		{
+			name: "invalid ip address",
+			sdp: `v=0
+o=- 1234567890 1234567890 IN IP4 1.2.3.4
+s=LiveKit
+c=IN IP4 invalid.ip
+t=0 0
+m=audio 1234 RTP/AVP 9 0 8 101
+a=rtpmap:9 G722/8000
+a=rtpmap:0 PCMU/8000
+a=rtpmap:8 PCMA/8000
+a=rtpmap:101 telephone-event/8000
+a=fmtp:101 0-16
+a=ptime:20
+a=sendrecv
+`,
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseOffer([]byte(test.sdp))
+			if test.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestParseOfferSRTP(t *testing.T) {
 	const sdpData = `v=0 
 o=lin 3723 713 IN IP4 192.168.0.2 


### PR DESCRIPTION
👋🏼  This patch addresses an issue in the media SDP parsing logic where session-level connection information (c=) was always used, even if a media-level c= was present. As I understand it media sections may override the session-level connection address; and if absent, they should inherit it.

Changes
- pkg/media/sdp/helpers.go
  - Updated GetAudioDest to first check audio.ConnectionInformation (media-level), then fall back to session.ConnectionInformation.
  - Preserves existing validity checks on ci.NetworkType and handles nil cases gracefully.
- pkg/media/sdp/offer.go
  - Existing logic now errors on invalid addresses instead of passing it along w/o errors.

#### Impact
- Downstream components relying on correct RTP addresses should no longer see spurious “invalid AddrPort” errors when media-level c= is present.
- In case of inavlid AddrPort there will be an explicit error in parsing media SDPs.
**In other words this means all SDPs parsed by this util will get an error if no media AddrPort is found: Is this a good assumption for media SDP parsing? We can omit this if we're not sure.**

#### Validation
- Added unit tests covering:
- SDP with only session-level c=
- SDP with both session- and media-level c= (media-level should win)
- SDP with no c= fields (should yield an invalid AddrPort)
- Invalid errors are bubbled up to the caller.

#### Links:
- https://datatracker.ietf.org/doc/html/rfc4566#section-5.7
- [RFC 4566 – Session Description Protocol](https://tools.ietf.org/html/rfc4566)
- [RFC 3605 – SDP Bandwidth Modifications for RTCP](https://tools.ietf.org/html/rfc3605)