### PR TITLE
Track mixer target output time between runs

### DIFF
--- a/pkg/internal/ringbuf/buffer.go
+++ b/pkg/internal/ringbuf/buffer.go
@@ -1,7 +1,6 @@
 package ringbuf
 
 import (
-	"fmt"
 	"io"
 )
 
@@ -97,7 +96,6 @@ func (b *Buffer[T]) Read(p []T) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	} else if b.Len() == 0 {
-		fmt.Println("EMPTY")
 		return 0, io.EOF
 	}
 	b.full = false
@@ -136,7 +134,6 @@ func (b *Buffer[T]) Write(p []T) (int, error) {
 			b.read = 0
 			b.write = 0
 			b.full = true
-			fmt.Println("FULL")
 			return n, nil
 		}
 		b.read = (b.read + dn) % len(b.buf) // drop old
@@ -151,8 +148,5 @@ func (b *Buffer[T]) Write(p []T) (int, error) {
 		n += dn
 	}
 	b.full = b.write == b.read
-	if b.full {
-		fmt.Println("FULL")
-	}
 	return n, nil
 }

--- a/pkg/internal/ringbuf/buffer.go
+++ b/pkg/internal/ringbuf/buffer.go
@@ -1,6 +1,9 @@
 package ringbuf
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
 
 // New creates a new ring buffer with s specified size.
 func New[T any](sz int) *Buffer[T] {
@@ -94,6 +97,7 @@ func (b *Buffer[T]) Read(p []T) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	} else if b.Len() == 0 {
+		fmt.Println("EMPTY")
 		return 0, io.EOF
 	}
 	b.full = false
@@ -132,6 +136,7 @@ func (b *Buffer[T]) Write(p []T) (int, error) {
 			b.read = 0
 			b.write = 0
 			b.full = true
+			fmt.Println("FULL")
 			return n, nil
 		}
 		b.read = (b.read + dn) % len(b.buf) // drop old
@@ -146,5 +151,8 @@ func (b *Buffer[T]) Write(p []T) (int, error) {
 		n += dn
 	}
 	b.full = b.write == b.read
+	if b.full {
+		fmt.Println("FULL")
+	}
 	return n, nil
 }

--- a/pkg/mixer/mixer.go
+++ b/pkg/mixer/mixer.go
@@ -130,6 +130,7 @@ func (m *Mixer) mixUpdate() {
 
 	if m.lastMixEndTs.IsZero() {
 		m.lastMixEndTs = now
+		n = 1
 	} else {
 		// In case scheduler stops us for too long, we will detect it and run mix multiple times.
 		// This happens if we get scheduled by OS/K8S on a lot of CPUs, but for a very short time.


### PR DESCRIPTION
When determining the amount of times to run the mixer, use the media end time enqueued during the previous run, instead of the wall clock time of the end of the last run. If the ticker runs late, or the mixing takes a non negligible amount of time, we would currently ignore partial frame times, potentially causing us to enqueue too little media.