### PR TITLE
Respond to SIP OPTIONS requests with 200 OK to support trunk provider heartbeat and connection validation

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -273,6 +273,10 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	return call.handleInvite(call.ctx, req, r.TrunkID, s.conf)
 }
 
+func (s *Server) onOptions(req *sip.Request, tx sip.ServerTransaction) {
+	_ = tx.Respond(sip.NewResponseFromRequest(req, 200, "OK", nil))
+}
+
 func (s *Server) onBye(req *sip.Request, tx sip.ServerTransaction) {
 	tag, err := getFromTag(req)
 	if err != nil {

--- a/pkg/sip/server.go
+++ b/pkg/sip/server.go
@@ -257,6 +257,7 @@ func (s *Server) Start(agent *sipgo.UserAgent, sc *ServiceConfig, unhandled Requ
 		return err
 	}
 
+	s.sipSrv.OnOptions(s.onOptions)
 	s.sipSrv.OnInvite(s.onInvite)
 	s.sipSrv.OnBye(s.onBye)
 	s.sipSrv.OnNotify(s.onNotify)


### PR DESCRIPTION
**Summary**
This change implements handling of the SIP OPTIONS method in the server. The server now responds with a 200 OK to inbound OPTIONS requests.

**Motivation**
Some SIP trunk providers — such as CM.com — require a valid response to periodic OPTIONS requests before they will route calls to a SIP destination. These requests function as a form of connection heartbeat, confirming the availability of the SIP endpoint. Without this (small) change, the SIP server cannot be used with certain SIP trunk providers.

**Implementation Details**
Added support for the OPTIONS method.

The server responds with 200 OK to any valid inbound OPTIONS request.