### PR TITLE
fix(sip): send 487 Request Terminated after OK (CANCEL) for pending INVITE

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1161,9 +1161,7 @@ func (c *sipInbound) StartRinging() {
 			case r := <-cancels:
 				close(c.cancelled)
 				_ = tx.Respond(sip.NewResponseFromRequest(r, sip.StatusOK, "OK", nil))
-				c.mu.Lock()
-				c.drop()
-				c.mu.Unlock()
+				c.RespondAndDrop(sip.StatusRequestTerminated, "Request Terminated")
 				return
 			case <-ticker.C:
 			}


### PR DESCRIPTION


When a CANCEL is received for an INVITE that hasn't been answered, the SIP gateway now correctly sends a 487 response to the original INVITE. This ensures proper SIP transaction termination and avoids issues where upstream proxies (e.g., Brekeke) keep the call in an INVITE state due to the missing final response.

closes #371 