### PR TITLE
Normalizing From and To Numbers for inbound calls

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -173,6 +173,14 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 		}
 		return AttrsToHeaders(r.LocalParticipant.Attributes(), c.attrsToHdr, headers)
 	})
+	fromUserAddress := cc.From()
+	fromUserAddress.User = lksip.NormalizeNumber(fromUserAddress.User)
+	cc.SetFromUser(fromUserAddress.User)
+
+	toUserAddress := cc.To()
+	toUserAddress.User = lksip.NormalizeNumber(toUserAddress.User)
+	cc.SetToUser(toUserAddress.User)
+
 	log = LoggerWithParams(log, cc)
 	log = LoggerWithHeaders(log, cc)
 	log.Infow("processing invite")
@@ -1104,6 +1112,18 @@ func (c *sipInbound) To() sip.Uri {
 		return sip.Uri{}
 	}
 	return c.to.Address
+}
+
+func (c *sipInbound) SetFromUser(user string) {
+	if c.from != nil {
+		c.from.Address.User = user
+	}
+}
+
+func (c *sipInbound) SetToUser(user string) {
+	if c.to != nil {
+		c.to.Address.User = user
+	}
 }
 
 func (c *sipInbound) ID() LocalTag {

--- a/pkg/sip/inbound_test.go
+++ b/pkg/sip/inbound_test.go
@@ -1,0 +1,90 @@
+package sip
+
+import (
+	"testing"
+
+	"github.com/livekit/sipgo/sip"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSIPInbound_SetFromUser(t *testing.T) {
+	testCases := []struct {
+		name     string
+		initial  *sip.FromHeader
+		newUser  string
+		expected string
+	}{
+		{
+			name: "sets user when From header exists",
+			initial: &sip.FromHeader{
+				Address: sip.Uri{
+					User: "olduser",
+				},
+			},
+			newUser:  "newuser",
+			expected: "newuser",
+		},
+		{
+			name:     "handles nil From header",
+			initial:  nil,
+			newUser:  "newuser",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inbound := &sipInbound{
+				from: tc.initial,
+			}
+			inbound.SetFromUser(tc.newUser)
+
+			if tc.initial == nil {
+				require.Equal(t, "", inbound.From().User)
+			} else {
+				require.Equal(t, tc.expected, inbound.From().User)
+			}
+		})
+	}
+}
+
+func TestSIPInbound_SetToUser(t *testing.T) {
+	testCases := []struct {
+		name     string
+		initial  *sip.ToHeader
+		newUser  string
+		expected string
+	}{
+		{
+			name: "sets user when To header exists",
+			initial: &sip.ToHeader{
+				Address: sip.Uri{
+					User: "olduser",
+				},
+			},
+			newUser:  "newuser",
+			expected: "newuser",
+		},
+		{
+			name:     "handles nil To header",
+			initial:  nil,
+			newUser:  "newuser",
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inbound := &sipInbound{
+				to: tc.initial,
+			}
+			inbound.SetToUser(tc.newUser)
+
+			if tc.initial == nil {
+				require.Equal(t, "", inbound.To().User)
+			} else {
+				require.Equal(t, tc.expected, inbound.To().User)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Certain carriers don't follow the E.164 format with numbers in the headers. This would lead to trunk matches failing and calls not working as expected. This takes care of that.