### PR TITLE
Detailed log for unhandled sip requests

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -304,6 +304,27 @@ func (s *Server) onBye(log *slog.Logger, req *sip.Request, tx sip.ServerTransact
 	}
 }
 
+func (s *Server) OnNoRoute(log *slog.Logger, req *sip.Request, tx sip.ServerTransaction) {
+	callID := ""
+	if h := req.CallID(); h != nil {
+		callID = h.Value()
+	}
+	from := ""
+	if h := req.From(); h != nil {
+		from = h.Address.String()
+	}
+	to := ""
+	if h := req.To(); h != nil {
+		to = h.Address.String()
+	}
+	s.log.Infow("Inbound SIP request not handled",
+		"method", req.Method.String(),
+		"callID", callID,
+		"from", from,
+		"to", to)
+	tx.Respond(sip.NewResponseFromRequest(req, 405, "Method Not Allowed", nil))
+}
+
 func (s *Server) onNotify(log *slog.Logger, req *sip.Request, tx sip.ServerTransaction) {
 	tag, err := getFromTag(req)
 	if err != nil {

--- a/pkg/sip/server.go
+++ b/pkg/sip/server.go
@@ -261,6 +261,7 @@ func (s *Server) Start(agent *sipgo.UserAgent, sc *ServiceConfig, unhandled Requ
 	s.sipSrv.OnInvite(s.onInvite)
 	s.sipSrv.OnBye(s.onBye)
 	s.sipSrv.OnNotify(s.onNotify)
+	s.sipSrv.OnNoRoute(s.OnNoRoute)
 	s.sipUnhandled = unhandled
 
 	// Ignore ACKs


### PR DESCRIPTION
This could make it easy to search logs when we have attributes like the call id but we haven't handled the sip request