### PR TITLE
Sending Request terminated status when Call is cancelled

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -960,7 +960,7 @@ func (c *inboundCall) closeWithCancelled() {
 	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
 		info.DisconnectReason = livekit.DisconnectReason_CLIENT_INITIATED
 	})
-	c.close(false, CallHangup, "cancelled")
+	c.close(false, CallCancelled, "cancelled")
 }
 
 func (c *inboundCall) closeWithHangup() {
@@ -1317,7 +1317,6 @@ func (c *sipInbound) StartRinging() {
 			case r := <-cancels:
 				close(c.cancelled)
 				_ = tx.Respond(sip.NewResponseFromRequest(r, sip.StatusOK, "OK", nil))
-				c.RespondAndDrop(sip.StatusRequestTerminated, "Request Terminated")
 				return
 			case <-ticker.C:
 			}

--- a/pkg/sip/participant.go
+++ b/pkg/sip/participant.go
@@ -68,6 +68,8 @@ func (v CallStatus) Attribute() string {
 		return "active"
 	case CallHangup:
 		return "hangup"
+	case CallCancelled:
+		return "cancelled"
 	}
 }
 
@@ -89,6 +91,8 @@ func (v CallStatus) SIPStatus() (sip.StatusCode, string) {
 	switch v {
 	default:
 		return sip.StatusBusyHere, "Rejected"
+	case CallCancelled:
+		return sip.StatusRequestTerminated, "RequestTerminated"
 	case callMediaFailed:
 		return sip.StatusNotAcceptableHere, "MediaFailed"
 	}
@@ -101,6 +105,7 @@ const (
 	CallRinging
 	CallAutomation
 	CallActive
+	CallCancelled
 	CallHangup
 	callUnavailable
 	callRejected


### PR DESCRIPTION
We observed that LiveKit SIP sometimes returned SIP status 486 Busy Here when a SIP caller canceled the call. This behavior was inconsistent with expected SIP cancellation handling.

Removed duplicate cancellation handling during ringing:
- Cancellation logic was previously executed in multiple places — both during ringing and WaitMedia.
- This caused incorrect status (like 486 Busy Here) to be returned when the call was simply canceled by the caller.

- Updated closeWithCancelled() to consistently mark the call as CallCancelled.
- Based on this status, the SIP response now correctly returns 487 Request Terminated, as per SIP spec for cancellations.

- Updated attributes to reflect that as well