### PR TITLE
Fixing test after #490

### DIFF
--- a/pkg/sip/protocol_test.go
+++ b/pkg/sip/protocol_test.go
@@ -88,7 +88,7 @@ func TestParseReason(t *testing.T) {
 				Cause: 200,
 				Text:  "Call completed elsewhere",
 			},
-			Normal: false,
+			Normal: true,
 		},
 		{
 			Name:   "Q.850",


### PR DESCRIPTION
Recent [commit 490](https://github.com/livekit/sip/commit/abd7948225a5732ac881c6fffa7e82ea470ca10e) broke tests explicitly expecting 200 Completed elsewhere to not be considered normal. 