### PR TITLE
pkg/sip/outbound.go: allow overwriting autogenerated SIP headers with ones suppiled by the user

### DIFF
--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -919,6 +919,9 @@ func (c *sipOutbound) attemptInvite(ctx context.Context, callID sip.CallIDHeader
 		req.AppendHeader(sip.NewHeader(authHeaderName, authHeader))
 	}
 	for _, h := range headers {
+		if req.GetHeader(h.Name()) != nil {
+			req.RemoveHeader(h.Name())
+		}
 		req.AppendHeader(h)
 	}
 


### PR DESCRIPTION
This allows users to override generated SIP headers and enables to achieve custom compatibility with a wide range of SIP-Servers/PBX-Systems.

For us this is a blocker for using LiveKit Cloud because it does not work with our existing telephony infrastructure.

Running livekip/sip locally with this change, we are able to place calls with our proprietary PBX system by constructing the From header ourselves.
