### PR TITLE
Optimize Docker image size by using smaller base image

### DIFF
--- a/build/sip/Dockerfile
+++ b/build/sip/Dockerfile
@@ -41,11 +41,11 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd
     -ldflags "-X github.com/livekit/sip/version.Version=${VERSION}" \
     -o livekit-sip ./cmd/livekit-sip
 
-FROM golang:$GOVERSION
+FROM debian:trixie-slim
 
 # install wget for health check
 RUN apt-get update && \
-    apt-get install -y libopus0 libopusfile0 libsoxr0 && \
+    apt-get install -y libopus0 libopusfile0 libsoxr0 ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The final base image in the Dockerfile can be trimmed by using a lightweight debian-slim image, since go and full debian image are not required in the final image.

Size Comparison:

|| Before | After |
| :--- | :---: | :---: |
| Compressed | 336MB | 55MB |
| Uncompressed | 970MB | 162MB |

The new image is ~83% smaller than the older image.