### PR TITLE
Fix build version injection via ldflags

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -68,6 +68,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -77,3 +81,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.docker-md.outputs.tags }}
           labels: ${{ steps.docker-md.outputs.labels }}
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}

--- a/build/sip/Dockerfile
+++ b/build/sip/Dockerfile
@@ -17,6 +17,7 @@ ARG GOVERSION=1.24
 FROM golang:$GOVERSION AS builder
 
 ARG TARGETPLATFORM
+ARG VERSION=0.0.0-dev
 
 WORKDIR /workspace
 
@@ -36,7 +37,9 @@ COPY version/ version/
 
 # build
 RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then GOARCH=arm64; else GOARCH=amd64; fi && \
-    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a -o livekit-sip ./cmd/livekit-sip
+    CGO_ENABLED=1 GOOS=linux GOARCH=${GOARCH} GO111MODULE=on go build -a \
+    -ldflags "-X github.com/livekit/sip/version.Version=${VERSION}" \
+    -o livekit-sip ./cmd/livekit-sip
 
 FROM golang:$GOVERSION
 

--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,5 @@
 
 package version
 
-const Version = "0.0.1"
+// Version is a var (not const) so it can be overridden at link time via ldflags
+var Version = "0.0.0-dev"


### PR DESCRIPTION
Fixes issue [535](https://github.com/livekit/sip/issues/535)
Pulls the version from the build tag and injects it using ldflags. 

Considerations: 
I update the default version to 0.0.0-dev to make it clear that this version is only for dev builds and will not show up in production builds. 

Changes Made:
- Add version extraction from git tag in GitHub workflow
- Pass VERSION build arg to Docker build
- Use ldflags to inject version at compile time
- Change Version to var to allow linker substitution
- Set default version to 0.0.0-dev for development builds