### PR TITLE
feat(tls): allow configuring TLS versions and cipher suites

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,8 +55,8 @@ type TLSConfig struct {
 	Certs      []TLSCert `yaml:"certs"`
 	KeyLog     string    `yaml:"key_log"`
 
-	MinVersion string `yaml:"min_version"` // min TLS version, accepts: "1.0", "1.1", "1.2", "1.3"
-	MaxVersion string `yaml:"max_version"` // max TLS version, accepts: "1.0", "1.1", "1.2", "1.3"
+	MinVersion string `yaml:"min_version"` // min TLS version, accepts: "tls1.0", "tls1.1", "tls1.2", "tls1.3"
+	MaxVersion string `yaml:"max_version"` // max TLS version, accepts: "tls1.0", "tls1.1", "tls1.2", "tls1.3"
 
 	// CipherSuites is an optional list of cipher suite names.
 	// If not provided, Go's secure defaults are used.

--- a/pkg/sip/service.go
+++ b/pkg/sip/service.go
@@ -261,21 +261,21 @@ func (s *Service) Start() error {
 		}
 
 		if len(tconf.CipherSuites) > 0 {
-			suits, err := ParseCipherSuites(tconf.CipherSuites, s.log)
+			suits, err := parseCipherSuites(s.log, tconf.CipherSuites)
 			if err != nil {
 				return err
 			}
 			tlsConf.CipherSuites = suits
 		}
 		if tconf.MinVersion != "" {
-			minVer, err := ParseTLSVersion(tconf.MinVersion)
+			minVer, err := parseTLSVersion(tconf.MinVersion)
 			if err != nil {
 				return err
 			}
 			tlsConf.MinVersion = minVer
 		}
 		if tconf.MaxVersion != "" {
-			maxVer, err := ParseTLSVersion(tconf.MaxVersion)
+			maxVer, err := parseTLSVersion(tconf.MaxVersion)
 			if err != nil {
 				return err
 			}

--- a/pkg/sip/tls.go
+++ b/pkg/sip/tls.go
@@ -60,9 +60,9 @@ func ConfigureTLS(c *tls.Config) {
 	}
 }
 
-// ParseCipherSuites parses cipher suite names to uint16 IDs.
+// parseCipherSuites parses cipher suite names to uint16 IDs.
 // Logs a warning for each insecure cipher suite configured.
-func ParseCipherSuites(suites []string, log logger.Logger) ([]uint16, error) {
+func parseCipherSuites(log logger.Logger, suites []string) ([]uint16, error) {
 	if len(suites) == 0 {
 		return nil, nil
 	}
@@ -85,19 +85,19 @@ func ParseCipherSuites(suites []string, log logger.Logger) ([]uint16, error) {
 	return parsedCipherSuites, nil
 }
 
-// ParseTLSVersion parses a TLS version string to its uint16 constant.
-// Accepts formats: "1.0", "1.1", "1.2", "1.3" or "TLS 1.0", "TLS 1.1", "TLS 1.2", "TLS 1.3".
-func ParseTLSVersion(version string) (uint16, error) {
+// parseTLSVersion parses a TLS version string to its uint16 constant.
+// Accepts formats: "tls1.0", "tls1.1", "tls1.2", "tls1.3" or "TLS1.0", "TLS1.1", "TLS1.2", "TLS1.3".
+func parseTLSVersion(version string) (uint16, error) {
 	switch version {
 	case "":
 		return 0, nil
-	case "1.0", "TLS 1.0":
+	case "tls1.0", "TLS1.0":
 		return tls.VersionTLS10, nil
-	case "1.1", "TLS 1.1":
+	case "tls1.1", "TLS1.1":
 		return tls.VersionTLS11, nil
-	case "1.2", "TLS 1.2":
+	case "tls1.2", "TLS1.2":
 		return tls.VersionTLS12, nil
-	case "1.3", "TLS 1.3":
+	case "tls1.3", "TLS1.3":
 		return tls.VersionTLS13, nil
 	default:
 		return 0, errors.New("unknown TLS version: " + version)

--- a/pkg/sip/tls_test.go
+++ b/pkg/sip/tls_test.go
@@ -18,7 +18,7 @@ func TestParseCipherSuites(t *testing.T) {
 			"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
 		}
 
-		suites, err := ParseCipherSuites(cipherSuites, log)
+		suites, err := parseCipherSuites(log, cipherSuites)
 
 		require.NoError(t, err)
 		require.Equal(t, len(cipherSuites), len(suites))
@@ -34,7 +34,7 @@ func TestParseCipherSuites(t *testing.T) {
 			"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
 		}
 
-		suites, err := ParseCipherSuites(cipherSuites, log)
+		suites, err := parseCipherSuites(log, cipherSuites)
 
 		require.NoError(t, err)
 		require.Equal(t, len(cipherSuites), len(suites))
@@ -49,7 +49,7 @@ func TestParseCipherSuites(t *testing.T) {
 			"TLS_ECDHE_RSA_WITH_RC4_128_SHA",
 		}
 
-		suites, err := ParseCipherSuites(cipherSuites, log)
+		suites, err := parseCipherSuites(log, cipherSuites)
 
 		require.NoError(t, err)
 		require.Equal(t, len(cipherSuites), len(suites))
@@ -63,7 +63,7 @@ func TestParseCipherSuites(t *testing.T) {
 			"INVALID_CIPHER_SUITE",
 		}
 
-		_, err := ParseCipherSuites(cipherSuites, log)
+		_, err := parseCipherSuites(log, cipherSuites)
 
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "unknown cipher suite: INVALID_CIPHER_SUITE")
@@ -71,69 +71,68 @@ func TestParseCipherSuites(t *testing.T) {
 }
 func TestParseTLSVersion(t *testing.T) {
 	t.Run("empty string", func(t *testing.T) {
-		version, err := ParseTLSVersion("")
+		version, err := parseTLSVersion("")
 		require.NoError(t, err)
 		require.Equal(t, uint16(0), version)
 	})
 
-	t.Run("TLS 1.0 - short format", func(t *testing.T) {
-		version, err := ParseTLSVersion("1.0")
+	t.Run("TLS 1.0 - lowercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("tls1.0")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS10), version)
 	})
 
-	t.Run("TLS 1.0 - long format", func(t *testing.T) {
-		version, err := ParseTLSVersion("TLS 1.0")
+	t.Run("TLS 1.0 - uppercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("TLS1.0")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS10), version)
 	})
 
-	t.Run("TLS 1.1 - short format", func(t *testing.T) {
-		version, err := ParseTLSVersion("1.1")
+	t.Run("TLS 1.1 - lowercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("tls1.1")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS11), version)
 	})
 
-	t.Run("TLS 1.1 - long format", func(t *testing.T) {
-		version, err := ParseTLSVersion("TLS 1.1")
+	t.Run("TLS 1.1 - uppercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("TLS1.1")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS11), version)
 	})
 
-	t.Run("TLS 1.2 - short format", func(t *testing.T) {
-		version, err := ParseTLSVersion("1.2")
+	t.Run("TLS 1.2 - lowercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("tls1.2")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS12), version)
 	})
 
-	t.Run("TLS 1.2 - long format", func(t *testing.T) {
-		version, err := ParseTLSVersion("TLS 1.2")
+	t.Run("TLS 1.2 - uppercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("TLS1.2")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS12), version)
 	})
 
-	t.Run("TLS 1.3 - short format", func(t *testing.T) {
-		version, err := ParseTLSVersion("1.3")
+	t.Run("TLS 1.3 - lowercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("tls1.3")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS13), version)
 	})
 
-	t.Run("TLS 1.3 - long format", func(t *testing.T) {
-		version, err := ParseTLSVersion("TLS 1.3")
+	t.Run("TLS 1.3 - uppercase format", func(t *testing.T) {
+		version, err := parseTLSVersion("TLS1.3")
 		require.NoError(t, err)
 		require.Equal(t, uint16(tls.VersionTLS13), version)
 	})
 
 	t.Run("invalid version", func(t *testing.T) {
-		_, err := ParseTLSVersion("1.4")
+		_, err := parseTLSVersion("tls1.4")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "unknown TLS version: 1.4")
+		require.Contains(t, err.Error(), "unknown TLS version: tls1.4")
 	})
 
 	t.Run("invalid format", func(t *testing.T) {
-		_, err := ParseTLSVersion("TLS1.2")
+		_, err := parseTLSVersion("TLS 1.2")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "unknown TLS version: TLS1.2")
+		require.Contains(t, err.Error(), "unknown TLS version: TLS 1.2")
 	})
 }
-


### PR DESCRIPTION
Expose configuration options for TLS MinVersion, MaxVersion, and CipherSuites backed by crypto/tls. This allows LiveKit to interoperate with providers that require non-default or legacy TLS configurations.