### PR TITLE
Adding more cases where remote end didn't allow for the

### DIFF
--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -840,7 +840,7 @@ func (c *sipOutbound) Invite(ctx context.Context, to URI, user, pass string, hea
 authLoop:
 	for try := 0; ; try++ {
 		if try >= 5 {
-			return nil, psrpc.NewError(psrpc.FailedPrecondition, fmt.Errorf("max auth retry attempts reached for sip invite"))
+			return nil, psrpc.NewError(psrpc.FailedPrecondition, fmt.Errorf("max auth retry attempts reached for SIP invite"))
 		}
 		req, resp, err = c.attemptInvite(ctx, sip.CallIDHeader(c.callID), toHeader, sdpOffer, authHeaderRespName, authHeader, sipHeaders, setState)
 		if err != nil {


### PR DESCRIPTION
outbound call to be terminated correctly using a failedPrecondition error