### PR TITLE
ffeat: Implement custom RFC 4733 DTMF decoding with End-bit detection

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1350,17 +1350,27 @@ func (c *inboundCall) playAudio(ctx context.Context, frames []msdk.PCM16Sample) 
 }
 
 func (c *inboundCall) handleDTMF(tone dtmf.Event) {
+	log := c.log()
+	log.Infow("DTMF received from phone", "digit", string(tone.Digit), "code", tone.Code, "forwardDTMF", c.forwardDTMF.Load())
+
 	if c.forwardDTMF.Load() {
-		_ = c.lkRoom.SendData(&livekit.SipDTMF{
+		err := c.lkRoom.SendData(&livekit.SipDTMF{
 			Code:  uint32(tone.Code),
 			Digit: string([]byte{tone.Digit}),
 		}, lksdk.WithDataPublishReliable(true))
+		if err != nil {
+			log.Warnw("Failed to forward DTMF to room", err, "digit", string(tone.Digit))
+		} else {
+			log.Infow("DTMF forwarded to room successfully", "digit", string(tone.Digit))
+		}
 		return
 	}
+	log.Debugw("DTMF not forwarded (forwardDTMF=false), buffering for PIN", "digit", string(tone.Digit))
 	// We should have enough buffer here.
 	select {
 	case c.dtmf <- tone:
 	default:
+		log.Warnw("DTMF buffer full, dropping tone", nil, "digit", string(tone.Digit))
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR implements custom DTMF RTP packet decoding that bypasses the Marker bit requirement 
from `media-sdk`, fixing an issue where DTMF events were silently dropped when SIP providers 
do not set the RTP Marker bit on DTMF packets.

## Problem

The existing `dtmf.DecodeRTP()` from `media-sdk` requires the RTP **Marker bit** to be set 
on incoming DTMF packets as specified in [RFC 4733](https://datatracker.ietf.org/doc/html/rfc4733). 
However, many SIP providers/gateways do not consistently set the Marker bit, causing DTMF 
events to be completely ignored. This results in:
- IVR/PIN input failures
- DTMF forwarding to LiveKit rooms silently failing
- No logging to indicate why DTMF was being dropped

## Solution

### Custom DTMF Decoding (`media_port.go`)
- Replaced `dtmf.DecodeRTP()` with a custom decoder that directly parses the 
  [RFC 4733 §2.3 payload format](https://datatracker.ietf.org/doc/html/rfc4733#section-2.3)
- Uses the **End bit** (byte 1, bit 7) instead of the Marker bit to determine when a DTMF 
  event is complete, preventing duplicate events
- Maps event codes (0-15) to their corresponding DTMF digits (`0-9`, `*`, `#`, `a-d`) 
  as defined in [RFC 4733 §7 (Event Code Registry)](https://datatracker.ietf.org/doc/html/rfc4733#section-7)
- Added debug/info logging for incoming DTMF RTP packets

### Improved DTMF Forwarding (`inbound.go`)
- Added structured logging throughout the DTMF handling pipeline
- Error handling for `SendData()` — previously errors were silently discarded with `_ =`
- Log messages for: DTMF received, forwarded successfully, forward failed, buffered for PIN, 
  and buffer full conditions

## Changes
- `pkg/sip/media_port.go` — Custom RFC 4733 DTMF payload decoding
- `pkg/sip/inbound.go` — Enhanced DTMF forwarding with error handling and logging

## References
- [RFC 4733 — RTP Payload for DTMF Digits, Telephony Tones, and Signals](https://datatracker.ietf.org/doc/html/rfc4733)
- [RFC 4733 §2.3 — Payload Format](https://datatracker.ietf.org/doc/html/rfc4733#section-2.3)
- [RFC 4733 §2.3.1 — Marker Bit](https://datatracker.ietf.org/doc/html/rfc4733#section-2.3.1)
- [RFC 4733 §7 — Event Code Registry](https://datatracker.ietf.org/doc/html/rfc4733#section-7)
- [RFC 2833 (Obsoleted by RFC 4733)](https://datatracker.ietf.org/doc/html/rfc2833)
- [livekit/media-sdks — DTMF DecodeRTP](https://github.com/livekit/media-sdks)

## Testing
- Tested with SIP providers that do not set the Marker bit on DTMF packets
- Verified DTMF digits are correctly decoded and forwarded to LiveKit rooms
- Confirmed no duplicate events due to End-bit filtering