### PR TITLE
fix: update packets_input stat after successful HandleRTP

### DIFF
--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -723,7 +723,6 @@ func (p *MediaPort) rtpReadLoop(tid traceid.ID, log logger.Logger, r rtp.ReadStr
 			p.stats.IgnoredPackets.Add(1)
 			continue
 		}
-		p.stats.InputPackets.Add(1)
 		err = hnd.HandleRTP(&h, buf[:n])
 		if err != nil {
 			if pipeline == "" {
@@ -743,6 +742,7 @@ func (p *MediaPort) rtpReadLoop(tid traceid.ID, log logger.Logger, r rtp.ReadStr
 			}
 			continue
 		}
+		p.stats.InputPackets.Add(1)
 		errorCnt = 0
 		pipeline = ""
 	}


### PR DESCRIPTION
per https://deepwiki.com/livekit/sip/7.5-media-statistics-and-monitoring, `InputPackets` stands for packets successfully handled, so we should update it only if err is nil.

<img width="760" height="78" alt="image" src="https://github.com/user-attachments/assets/622934ea-c793-4c01-bf7d-bf47069775e4" />
