### PR TITLE
add sip.verbose_call_logging feature flag

### DIFF
--- a/pkg/sip/client.go
+++ b/pkg/sip/client.go
@@ -345,7 +345,7 @@ func (c *Client) onBye(req *sip.Request, tx sip.ServerTransaction) bool {
 	c.cmu.Unlock()
 	if call == nil {
 		if tag != "" {
-			c.log.Infow("BYE for non-existent call", "sipTag", tag)
+			c.log.Debugw("BYE for non-existent call", "sipTag", tag)
 		}
 		_ = tx.Respond(sip.NewResponseFromRequest(req, sip.StatusCallTransactionDoesNotExists, "Call does not exist", nil))
 		return false

--- a/pkg/sip/features.go
+++ b/pkg/sip/features.go
@@ -3,4 +3,5 @@ package sip
 const (
 	signalLoggingFeatureFlag        = "sip.signal_logging"
 	outboundRouteHeadersFeatureFlag = "sip.outbound_route_headers"
+	verboseCallLoggingFeatureFlag   = "sip.verbose_call_logging"
 )

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -536,7 +536,7 @@ func (s *Server) onBye(log *slog.Logger, req *sip.Request, tx sip.ServerTransact
 		ok = s.sipUnhandled(req, tx)
 	}
 	if !ok {
-		s.log.Infow("BYE for non-existent call", "callID", tag)
+		s.log.Debugw("BYE for non-existent call", "callID", tag)
 		_ = tx.Respond(sip.NewResponseFromRequest(req, sip.StatusCallTransactionDoesNotExists, "Call does not exist", nil))
 	}
 }
@@ -616,11 +616,12 @@ type inboundCall struct {
 	joinDur     func() time.Duration
 	forwardDTMF atomic.Bool
 	done        atomic.Bool
-	started     core.Fuse
-	stats       Stats
-	sigTs       SignalingTimestamps
-	jitterBuf   bool
-	projectID   string
+	started        core.Fuse
+	stats          Stats
+	sigTs          SignalingTimestamps
+	jitterBuf      bool
+	verboseLogging bool
+	projectID      string
 }
 
 func (s *Server) newInboundCall(
@@ -892,6 +893,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	}
 	disp.Room.JitterBuf = c.jitterBuf
 	disp.Room.LogSignalChanges, _ = strconv.ParseBool(disp.FeatureFlags[signalLoggingFeatureFlag])
+	c.verboseLogging, _ = strconv.ParseBool(disp.FeatureFlags[verboseCallLoggingFeatureFlag])
 	ctx, cancel := context.WithTimeout(ctx, disp.MaxCallDuration)
 	defer cancel()
 	status := CallRinging
@@ -996,6 +998,7 @@ func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, enc livekit
 		SymmetricRTP:        conf.SymmetricRTP,
 		EnableJitterBuffer:  c.jitterBuf,
 		LogSignalChanges:    logSignalChanges,
+		VerboseLogging:      c.verboseLogging,
 		Stats:               &c.stats.Port,
 		NoInputResample:     !RoomResample,
 	}, RoomSampleRate)
@@ -1166,7 +1169,7 @@ func (c *inboundCall) pinPrompt(ctx context.Context, trunkID string) (disp CallD
 }
 
 func (c *inboundCall) printStats(log logger.Logger) {
-	c.stats.Log(log, c.callStart)
+	c.stats.Log(log, c.callStart, c.verboseLogging)
 }
 
 // close should only be called from handleInvite.

--- a/pkg/sip/media.go
+++ b/pkg/sip/media.go
@@ -113,17 +113,22 @@ func (s *Stats) Load() StatsSnapshot {
 	}
 }
 
-func (s *Stats) Log(log logger.Logger, callStart time.Time) {
+func (s *Stats) Log(log logger.Logger, callStart time.Time, verbose bool) {
 	const expectedSampleRate = RoomSampleRate
 	st := s.Load()
-	log.Infow("call statistics",
+	args := []any{
 		"stats", st,
 		"durMin", int(time.Since(callStart).Minutes()),
 		"sip_rx_ppm", ratePPM(st.Port.AudioRX, expectedSampleRate),
 		"sip_tx_ppm", ratePPM(st.Port.AudioTX, expectedSampleRate),
 		"lk_publish_ppm", ratePPM(st.Room.PublishTX, expectedSampleRate),
 		"expected_pcm_hz", expectedSampleRate,
-	)
+	}
+	if verbose {
+		log.Infow("call statistics", args...)
+	} else {
+		log.Debugw("call statistics", args...)
+	}
 }
 
 func (s *Stats) MarshalJSON() ([]byte, error) {

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -198,18 +198,19 @@ type UDPConn interface {
 	WriteToUDPAddrPort(b []byte, addr netip.AddrPort) (int, error)
 }
 
-func newUDPConn(log logger.Logger, conn UDPConn, symmetricRTP bool) *udpConn {
-	return &udpConn{UDPConn: conn, log: log, stopped: make(chan struct{}), symmetricRTP: symmetricRTP}
+func newUDPConn(log logger.Logger, conn UDPConn, symmetricRTP bool, verboseLogging bool) *udpConn {
+	return &udpConn{UDPConn: conn, log: log, stopped: make(chan struct{}), symmetricRTP: symmetricRTP, verboseLogging: verboseLogging}
 }
 
 type udpConn struct {
 	UDPConn
-	stopping     core.Fuse
-	stopped      chan struct{}
-	log          logger.Logger
-	symmetricRTP bool
-	src          atomic.Pointer[netip.AddrPort]
-	dst          atomic.Pointer[netip.AddrPort]
+	stopping       core.Fuse
+	stopped        chan struct{}
+	log            logger.Logger
+	symmetricRTP   bool
+	verboseLogging bool
+	src            atomic.Pointer[netip.AddrPort]
+	dst            atomic.Pointer[netip.AddrPort]
 }
 
 func (c *udpConn) GetSrc() (netip.AddrPort, bool) {
@@ -227,7 +228,7 @@ func (c *udpConn) SetDst(addr netip.AddrPort) {
 		if prev == nil || !prev.IsValid() {
 			c.log.Infow("setting media destination", "addr", addr.String())
 		} else if *prev != addr {
-			c.log.Infow("changing media destination", "addr", addr.String())
+			c.logMediaChange("changing media destination", "addr", addr.String())
 		}
 	}
 }
@@ -238,7 +239,7 @@ func (c *udpConn) Read(b []byte) (n int, err error) {
 	if prev == nil || !prev.IsValid() {
 		c.log.Infow("setting media source", "addr", addr.String())
 	} else if *prev != addr {
-		c.log.Infow("changing media source", "addr", addr.String())
+		c.logMediaChange("changing media source", "addr", addr.String())
 	}
 	if c.symmetricRTP {
 		dst := c.dst.Load()
@@ -247,6 +248,14 @@ func (c *udpConn) Read(b []byte) (n int, err error) {
 		}
 	}
 	return n, err
+}
+
+func (c *udpConn) logMediaChange(msg string, args ...any) {
+	if c.verboseLogging {
+		c.log.Infow(msg, args...)
+	} else {
+		c.log.Debugw(msg, args...)
+	}
 }
 
 func (c *udpConn) Write(b []byte) (n int, err error) {
@@ -315,6 +324,7 @@ type MediaOptions struct {
 	NoInputResample     bool
 	IgnorePreanswerData bool
 	LogSignalChanges    bool
+	VerboseLogging      bool
 }
 
 func NewMediaPort(tid traceid.ID, log logger.Logger, mon *stats.CallMonitor, opts *MediaOptions, sampleRate int) (*MediaPort, error) {
@@ -356,7 +366,7 @@ func NewMediaPortWith(tid traceid.ID, log logger.Logger, mon *stats.CallMonitor,
 		timeoutResetTick: make(chan time.Duration, 1),
 		jitterEnabled:    opts.EnableJitterBuffer,
 		logSignalChanges: opts.LogSignalChanges,
-		port:             newUDPConn(log, conn, opts.SymmetricRTP),
+		port:             newUDPConn(log, conn, opts.SymmetricRTP, opts.VerboseLogging),
 		audioOut:         msdk.NewSwitchWriter(sampleRate),
 		audioIn:          msdk.NewSwitchWriter(inSampleRate),
 		stats:            opts.Stats,

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -81,8 +81,9 @@ type outboundCall struct {
 	closing   core.Fuse
 	stats     Stats
 	sigTs     SignalingTimestamps
-	jitterBuf bool
-	projectID string
+	jitterBuf      bool
+	verboseLogging bool
+	projectID      string
 
 	mu       sync.RWMutex
 	mon      *stats.CallMonitor
@@ -93,6 +94,7 @@ type outboundCall struct {
 
 func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Config, log logger.Logger, id LocalTag, room RoomConfig, sipConf sipOutboundConfig, state *CallState, projectID string) (*outboundCall, error) {
 	signalLoggingEnabled, _ := strconv.ParseBool(sipConf.featureFlags[signalLoggingFeatureFlag])
+	verboseCallLogging, _ := strconv.ParseBool(sipConf.featureFlags[verboseCallLoggingFeatureFlag])
 	if sipConf.maxCallDuration <= 0 || sipConf.maxCallDuration > maxCallDuration {
 		sipConf.maxCallDuration = maxCallDuration
 	}
@@ -110,15 +112,16 @@ func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Confi
 	}
 	now := time.Now()
 	call := &outboundCall{
-		c:         c,
-		tid:       tid,
-		log:       log,
-		sipConf:   sipConf,
-		state:     state,
-		callStart: now,
-		sigTs:     SignalingTimestamps{APITime: now},
-		jitterBuf: jitterBuf,
-		projectID: projectID,
+		c:              c,
+		tid:            tid,
+		log:            log,
+		sipConf:        sipConf,
+		state:          state,
+		callStart:      now,
+		sigTs:          SignalingTimestamps{APITime: now},
+		jitterBuf:      jitterBuf,
+		verboseLogging: verboseCallLogging,
+		projectID:      projectID,
 	}
 	call.stats.Update()
 	call.log = call.log.WithValues("jitterBuf", call.jitterBuf)
@@ -153,6 +156,7 @@ func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Confi
 		SymmetricRTP:        c.conf.SymmetricRTP,
 		EnableJitterBuffer:  call.jitterBuf,
 		LogSignalChanges:    signalLoggingEnabled,
+		VerboseLogging:      verboseCallLogging,
 		Stats:               &call.stats.Port,
 		NoInputResample:     !RoomResample,
 		IgnorePreanswerData: true,
@@ -308,7 +312,7 @@ func (c *outboundCall) closeWithTimeout(ctx context.Context) {
 }
 
 func (c *outboundCall) printStats() {
-	c.stats.Log(c.log, c.callStart)
+	c.stats.Log(c.log, c.callStart, c.verboseLogging)
 }
 
 func (c *outboundCall) close(ctx context.Context, err error, status CallStatus, description string, reason livekit.DisconnectReason) {


### PR DESCRIPTION
Move "changing media source/destination" and "call statistics" logs from Info to Debug by default. When the sip.verbose_call_logging project flag is enabled, these logs are emitted at Info level. Also move "BYE for non-existent call" to Debug unconditionally.