### PR TITLE
fix: bind SIP media sockets to signaling interface

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -990,6 +990,7 @@ func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, enc livekit
 	logSignalChanges, _ = strconv.ParseBool(featureFlags[signalLoggingFeatureFlag])
 	mp, err := NewMediaPort(tid, c.log(), c.mon, &MediaOptions{
 		IP:                  c.s.sconf.MediaIP,
+		BindIP:              c.s.sconf.SignalingIPLocal,
 		Ports:               conf.RTPPort,
 		MediaTimeoutInitial: c.s.conf.MediaTimeoutInitial,
 		MediaTimeout:        c.s.conf.MediaTimeout,

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -306,6 +306,7 @@ type MediaConf struct {
 
 type MediaOptions struct {
 	IP                  netip.Addr
+	BindIP              netip.Addr
 	Ports               rtcconfig.PortRange
 	MediaTimeoutInitial time.Duration
 	MediaTimeout        time.Duration
@@ -335,7 +336,11 @@ func NewMediaPortWith(tid traceid.ID, log logger.Logger, mon *stats.CallMonitor,
 		opts.Stats = &PortStats{}
 	}
 	if conn == nil {
-		c, err := rtp.ListenUDPPortRange(opts.Ports.Start, opts.Ports.End, netip.AddrFrom4([4]byte{0, 0, 0, 0}))
+		bindIP := opts.BindIP
+		if !bindIP.IsValid() {
+			bindIP = netip.AddrFrom4([4]byte{0, 0, 0, 0})
+		}
+		c, err := rtp.ListenUDPPortRange(opts.Ports.Start, opts.Ports.End, bindIP)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -147,6 +147,7 @@ func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Confi
 
 	call.media, err = NewMediaPort(tid, call.log, call.mon, &MediaOptions{
 		IP:                  c.sconf.MediaIP,
+		BindIP:              c.sconf.SignalingIPLocal,
 		Ports:               conf.RTPPort,
 		MediaTimeoutInitial: c.conf.MediaTimeoutInitial,
 		MediaTimeout:        c.conf.MediaTimeout,


### PR DESCRIPTION
## Summary

  This change binds SIP media sockets to the same local interface used for SIP signaling instead of listening on `0.0.0.0`.

  ## Problem

  In multi-homed / NATed production environments, SIP signaling and RTP could leave the host through different interfaces/IPs:

  - SIP signaling was advertised and sent using the configured signaling IP
  - RTP sockets were created on `0.0.0.0`
  - The kernel could then route media through a different interface/public IP

  Some SIP providers validate that registration/signaling and call media originate from the same IP. In our case this caused providers to reject calls as illegitimate.

  ## Change

  - Added `BindIP` to `MediaOptions`
  - Changed `NewMediaPortWith` to bind RTP sockets to `BindIP` when provided
  - Passed `SignalingIPLocal` as `BindIP` for both outbound and inbound SIP media

  ## Expected result

  RTP now uses the same local interface as SIP signaling, which makes the effective external path much more stable and avoids cases where providers reject calls because signaling and media appear to originate from different IPs.

  ## Notes

  This change is intentionally narrow:
  - no registration logic changes
  - no config/API changes
  - only socket binding behavior for SIP media