### PR TITLE
TEL-455: instrument call termination

### DIFF
--- a/pkg/sip/client.go
+++ b/pkg/sip/client.go
@@ -349,7 +349,7 @@ func (c *Client) onBye(req *sip.Request, tx sip.ServerTransaction) bool {
 	call.log.Infow("BYE from remote")
 	go func(call *outboundCall) {
 		call.cc.AcceptBye(req, tx)
-		call.CloseWithReason(ctx, CallHangup, "bye", livekit.DisconnectReason_CLIENT_INITIATED)
+		call.CloseWithReason(ctx, CallHangup, stats.Success("bye"), livekit.DisconnectReason_CLIENT_INITIATED)
 	}(call)
 	return true
 }

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -403,7 +403,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	tauth()
 	checked()
 	if err != nil {
-		cmon.InviteErrorShort("auth-error")
+		cmon.InviteErrorShort(stats.ServerError("auth-error"))
 		log.Warnw("Rejecting inbound, auth check failed", err)
 		cc.RespondAndDrop(sip.StatusServiceUnavailable, "Try again later")
 		return psrpc.NewError(psrpc.PermissionDenied, errors.Wrap(err, "rejecting inbound, auth check failed"))
@@ -431,22 +431,22 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 
 	switch r.Result {
 	case AuthDrop:
-		cmon.InviteErrorShort("flood")
+		cmon.InviteErrorShort(stats.ClientError("flood"))
 		log.Debugw("Dropping inbound flood")
 		cc.Drop()
 		return psrpc.NewErrorf(psrpc.PermissionDenied, "call was not authorized by trunk configuration")
 	case AuthNotFound:
-		cmon.InviteErrorShort("no-rule")
+		cmon.InviteErrorShort(stats.ClientError("no-rule"))
 		log.Warnw("Rejecting inbound, doesn't match any Trunks", nil)
 		cc.RespondAndDrop(sip.StatusNotFound, "Does not match any SIP Trunks")
 		return psrpc.NewErrorf(psrpc.NotFound, "no trunk configuration for call")
 	case AuthQuotaExceeded:
-		cmon.InviteErrorShort("quota-exceeded")
+		cmon.InviteErrorShort(stats.ClientError("quota-exceeded"))
 		log.Warnw("Rejecting inbound, quota exceeded", nil)
 		cc.RespondAndDrop(sip.StatusServiceUnavailable, "Service temporarily unavailable")
 		return psrpc.NewErrorf(psrpc.ResourceExhausted, "quota limit exceeded")
 	case AuthNoTrunkFound:
-		cmon.InviteErrorShort("no-trunk")
+		cmon.InviteErrorShort(stats.ClientError("no-trunk"))
 		log.Warnw("Rejecting inbound, no trunk found", nil)
 		cc.RespondAndDrop(sip.StatusNotFound, "No trunk found")
 		return psrpc.NewErrorf(psrpc.NotFound, "no trunk found for call")
@@ -462,7 +462,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 			s.cmu.Lock()
 			s.provisionalInvites.Add([2]string{cc.SIPCallID(), string(cc.Tag())}, cc.ID())
 			s.cmu.Unlock()
-			cmon.InviteErrorShort("unauthorized")
+			cmon.InviteErrorShort(stats.ClientError("unauthorized"))
 			// handleInviteAuth will generate the SIP Response as needed
 			return psrpc.NewErrorf(psrpc.PermissionDenied, "invalid credentials were provided")
 		}
@@ -697,7 +697,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	c.mon.InviteAccept()
 	c.mon.CallStart()
 	defer c.mon.CallEnd()
-	defer c.close(ctx, true, callDropped, "other")
+	defer c.close(ctx, callDropped, stats.ServerError("other"))
 
 	// Extract and store the SIP call ID from the request
 	if h := req.CallID(); h != nil {
@@ -750,22 +750,22 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		err := fmt.Errorf("unexpected dispatch result: %v", disp.Result)
 		c.log().Errorw("Rejecting inbound call", err)
 		c.cc.RespondAndDrop(sip.StatusNotImplemented, "")
-		c.close(ctx, true, callDropped, "unexpected-result")
+		c.close(ctx, callDropped, stats.ServerError("unexpected-result"))
 		return psrpc.NewError(psrpc.Unimplemented, err)
 	case DispatchNoRuleDrop:
 		c.log().Debugw("Rejecting inbound flood")
 		c.cc.Drop()
-		c.close(ctx, false, callFlood, "flood")
+		c.close(ctx, callFlood, stats.ClientError("flood"))
 		return psrpc.NewErrorf(psrpc.PermissionDenied, "call was not authorized by trunk configuration")
 	case DispatchNoRuleReject:
 		c.log().Infow("Rejecting inbound call, doesn't match any Dispatch Rules")
 		c.cc.RespondAndDrop(sip.StatusNotFound, "Does not match Trunks or Dispatch Rules")
-		c.close(ctx, false, callDropped, "no-dispatch")
+		c.close(ctx, callDropped, stats.ClientError("no-dispatch"))
 		return psrpc.NewErrorf(psrpc.NotFound, "no trunk configuration for call")
 	case DispatchServiceUnavailable:
 		c.log().Warnw("Rejecting inbound call, dispatch evaluation failed", nil)
 		c.cc.RespondAndDrop(sip.StatusServiceUnavailable, "Try again later")
-		c.close(ctx, true, callDropped, "dispatch-error")
+		c.close(ctx, callDropped, stats.ServerError("dispatch-error"))
 		return psrpc.NewErrorf(psrpc.Unavailable, "dispatch rule evaluation unavailable")
 	case DispatchAccept:
 		pinPrompt = false
@@ -795,15 +795,15 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		if err != nil {
 			sipReason := sip.StatusInternalServerError
 			log = log.WithValues("sdp", string(rawSDP))
-			status, reason := callDropped, "media-failed"
+			status, term := callDropped, stats.ServerError("media-failed")
 			if errors.Is(err, sdp.ErrNoCommonMedia) {
-				status, reason = callMediaFailed, "no-common-codec"
+				status, term = callMediaFailed, stats.ClientError("no-common-codec")
 				sipReason = sip.StatusBadRequest
 			} else if errors.Is(err, sdp.ErrNoCommonCrypto) {
-				status, reason = callMediaFailed, "no-common-crypto"
+				status, term = callMediaFailed, stats.ClientError("no-common-crypto")
 				sipReason = sip.StatusBadRequest
 			} else if e := (SDPError{}); errors.As(err, &e) {
-				status, reason = callMediaFailed, "sdp-error"
+				status, term = callMediaFailed, stats.ClientError("sdp-error")
 				sipReason = sip.StatusBadRequest
 			}
 			if sipReason >= 500 {
@@ -812,7 +812,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 				log.Warnw("Cannot start media", err)
 			}
 			c.cc.RespondAndDrop(sipReason, "")
-			c.close(ctx, true, status, reason)
+			c.close(ctx, status, term)
 			return nil, err
 		}
 		return answerData, nil
@@ -844,7 +844,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 			return false, err
 		} else if err != nil {
 			c.log().Errorw("Cannot accept the call", err)
-			c.close(ctx, true, callAcceptFailed, "accept-failed")
+			c.close(ctx, callAcceptFailed, stats.ServerError("accept-failed"))
 			return false, err
 		}
 		if !c.s.conf.Experimental.InboundWaitACK {
@@ -909,7 +909,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	// Publish our own track.
 	if err := c.publishTrack(); err != nil {
 		c.log().Errorw("Cannot publish track", err)
-		c.close(ctx, true, callDropped, "publish-failed")
+		c.close(ctx, callDropped, stats.ServerError("publish-failed"))
 		return errors.Wrap(err, "publishing track to room failed")
 	}
 	tsub := c.mon.StageDurTimer("track-subscribe")
@@ -966,7 +966,7 @@ func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan str
 			c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
 				info.DisconnectReason = livekit.DisconnectReason_CLIENT_INITIATED
 			})
-			c.close(ctx, false, callDropped, "removed")
+			c.close(ctx, callDropped, stats.Success("removed"))
 			return nil
 		case <-c.media.Timeout():
 			return c.mediaTimeout(ctx)
@@ -1096,7 +1096,7 @@ func (c *inboundCall) waitSubscribe(ctx context.Context, timeout time.Duration) 
 	case <-c.media.Timeout():
 		return false, c.mediaTimeout(ctx)
 	case <-timer.C:
-		c.close(ctx, false, callDropped, "cannot-subscribe")
+		c.close(ctx, callDropped, stats.ServerError("cannot-subscribe"))
 		return false, psrpc.NewErrorf(psrpc.DeadlineExceeded, "room subscription timed out")
 	case <-c.lkRoom.Subscribed():
 		return true, nil
@@ -1152,13 +1152,13 @@ func (c *inboundCall) pinPrompt(ctx context.Context, trunkID string) (disp CallD
 				}
 				if disp.Result == DispatchServiceUnavailable {
 					c.log().Warnw("Rejecting call, dispatch evaluation failed", nil, "pin", pin, "noPin", noPin)
-					c.close(ctx, true, callDropped, "dispatch-error")
+					c.close(ctx, callDropped, stats.ServerError("dispatch-error"))
 					return disp, false, psrpc.NewErrorf(psrpc.Unavailable, "dispatch rule evaluation unavailable")
 				}
 				if disp.Result != DispatchAccept || disp.Room.RoomName == "" {
 					c.log().Infow("Rejecting call", "pin", pin, "noPin", noPin)
 					c.playAudio(ctx, c.s.res.wrongPin)
-					c.close(ctx, false, callDropped, "wrong-pin")
+					c.close(ctx, callDropped, stats.ClientError("wrong-pin"))
 					return disp, false, psrpc.NewErrorf(psrpc.PermissionDenied, "wrong pin")
 				}
 				c.playAudio(ctx, c.s.res.roomJoin)
@@ -1168,7 +1168,7 @@ func (c *inboundCall) pinPrompt(ctx context.Context, trunkID string) (disp CallD
 			pin += string(b.Digit)
 			if len(pin) > pinLimit {
 				c.playAudio(ctx, c.s.res.wrongPin)
-				c.close(ctx, false, callDropped, "wrong-pin")
+				c.close(ctx, callDropped, stats.ClientError("wrong-pin"))
 				return disp, false, psrpc.NewErrorf(psrpc.PermissionDenied, "wrong pin")
 			}
 		}
@@ -1180,7 +1180,7 @@ func (c *inboundCall) printStats(log logger.Logger) {
 }
 
 // close should only be called from handleInvite.
-func (c *inboundCall) close(ctx context.Context, error bool, status CallStatus, reason string) {
+func (c *inboundCall) close(ctx context.Context, status CallStatus, t stats.Termination) {
 	termCtx, cancel := context.WithCancel(context.Background()) // Do not use ctx
 	defer cancel()
 	go func() {
@@ -1200,15 +1200,15 @@ func (c *inboundCall) close(ctx context.Context, error bool, status CallStatus, 
 	defer c.mon.StageDurTimer("close")
 	c.stats.Closed.Store(true)
 	sipCode, sipStatus := status.SIPStatus()
-	log := c.log().WithValues("status", sipCode, "reason", reason)
+	log := c.log().WithValues("status", sipCode, "result", string(t.Result), "reason", t.Reason)
 	defer func() {
 		c.stats.Update()
 		c.printStats(log)
 		c.sigTs.Log(log)
 	}()
 	c.setStatus(status)
-	c.mon.CallTerminate(reason)
-	isWarn := error || status == callHangupMedia
+	c.mon.CallTerminate(t)
+	isWarn := t.Result == stats.ResultServerError || status == callHangupMedia
 	if isWarn {
 		log.Warnw("Closing inbound call with error", nil)
 	} else {
@@ -1243,7 +1243,7 @@ func (c *inboundCall) close(ctx context.Context, error bool, status CallStatus, 
 				ProjectID: c.projectID,
 				CallID:    c.call.LkCallId,
 				SipCallID: c.call.SipCallId,
-			}, c.state.callInfo, reason)
+			}, c.state.callInfo, t.Reason)
 		}(c.tid)
 	}
 
@@ -1255,11 +1255,11 @@ func (c *inboundCall) closeWithTimeout(ctx context.Context, isError bool) {
 	if !isError {
 		status = callHangupMedia
 	}
-	c.close(ctx, isError, status, "media-timeout")
+	c.close(ctx, status, stats.ServerError("media-timeout"))
 }
 
 func (c *inboundCall) closeWithNoACK(ctx context.Context) {
-	c.close(ctx, true, callNoACK, "no-ack")
+	c.close(ctx, callNoACK, stats.ServerError("no-ack"))
 }
 
 func (c *inboundCall) closeWithCancelled(ctx context.Context) {
@@ -1267,7 +1267,7 @@ func (c *inboundCall) closeWithCancelled(ctx context.Context) {
 	if p := c.closeReason.Load(); p != nil {
 		reason = *p
 	}
-	c.closeWithReason(ctx, CallHangup, "cancelled", reason)
+	c.closeWithReason(ctx, CallHangup, stats.Success("cancelled"), reason)
 }
 
 func (c *inboundCall) closeWithHangup(ctx context.Context) {
@@ -1275,10 +1275,10 @@ func (c *inboundCall) closeWithHangup(ctx context.Context) {
 	if p := c.closeReason.Load(); p != nil {
 		reason = *p
 	}
-	c.closeWithReason(ctx, CallHangup, "hangup", reason)
+	c.closeWithReason(ctx, CallHangup, stats.Success("hangup"), reason)
 }
 
-func (c *inboundCall) closeWithReason(ctx context.Context, status CallStatus, reasonName string, reason ReasonHeader) {
+func (c *inboundCall) closeWithReason(ctx context.Context, status CallStatus, t stats.Termination, reason ReasonHeader) {
 	ctx = context.WithoutCancel(ctx)
 	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
 		info.DisconnectReason = livekit.DisconnectReason_CLIENT_INITIATED
@@ -1290,10 +1290,10 @@ func (c *inboundCall) closeWithReason(ctx context.Context, status CallStatus, re
 	})
 	if reason.Type != "" {
 		if !reason.IsNormal() {
-			reasonName = fmt.Sprintf("bye-%s-%d", strings.ToLower(reason.Type), reason.Cause)
+			t.Reason = fmt.Sprintf("bye-%s-%d", strings.ToLower(reason.Type), reason.Cause)
 		}
 	}
-	c.close(ctx, false, status, reasonName)
+	c.close(ctx, status, t)
 }
 
 func (c *inboundCall) Bye(reason ReasonHeader) {
@@ -1390,7 +1390,7 @@ func (c *inboundCall) joinRoom(ctx context.Context, rconf RoomConfig, status Cal
 	c.log().Infow("Joining room")
 	if err := c.createLiveKitParticipant(ctx, rconf, status); err != nil {
 		c.log().Errorw("Cannot create LiveKit participant", err)
-		c.close(ctx, true, callDropped, "participant-failed")
+		c.close(ctx, callDropped, stats.ServerError("participant-failed"))
 		return errors.Wrap(err, "cannot create LiveKit participant")
 	}
 	return nil

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -158,14 +158,14 @@ func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Confi
 		IgnorePreanswerData: true,
 	}, RoomSampleRate)
 	if err != nil {
-		call.close(ctx, errors.Wrap(err, "media failed"), callDropped, "media-failed", livekit.DisconnectReason_UNKNOWN_REASON)
+		call.close(ctx, errors.Wrap(err, "media failed"), callDropped, stats.ServerError("media-failed"), livekit.DisconnectReason_UNKNOWN_REASON)
 		return nil, err
 	}
 	call.media.SetDTMFAudio(conf.AudioDTMF)
 	call.media.EnableTimeout(false)
 	call.media.DisableOut() // disabled until we get 200
 	if err := call.connectToRoom(ctx, room, c.getRoom); err != nil {
-		call.close(ctx, errors.Wrap(err, "room join failed"), callDropped, "join-failed", livekit.DisconnectReason_UNKNOWN_REASON)
+		call.close(ctx, errors.Wrap(err, "room join failed"), callDropped, stats.ServerError("join-failed"), livekit.DisconnectReason_UNKNOWN_REASON)
 		return nil, psrpc.NewError(psrpc.Internal, fmt.Errorf("update room failed: %w", err))
 	}
 
@@ -255,7 +255,7 @@ func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
 			c.log.Debugw("sending keep-alive")
 			c.state.ForceFlush(ctx)
 		case <-c.Disconnected():
-			c.CloseWithReason(ctx, callDropped, "removed", livekit.DisconnectReason_CLIENT_INITIATED)
+			c.CloseWithReason(ctx, callDropped, stats.Success("removed"), livekit.DisconnectReason_CLIENT_INITIATED)
 			return nil
 		case <-c.media.Timeout():
 			c.closeWithTimeout(ctx)
@@ -291,32 +291,32 @@ func (c *outboundCall) Disconnected() <-chan struct{} {
 func (c *outboundCall) Close(ctx context.Context) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.close(ctx, nil, callDropped, "shutdown", livekit.DisconnectReason_SERVER_SHUTDOWN)
+	c.close(ctx, nil, callDropped, stats.ServerError("shutdown"), livekit.DisconnectReason_SERVER_SHUTDOWN)
 	return nil
 }
 
-func (c *outboundCall) CloseWithReason(ctx context.Context, status CallStatus, description string, reason livekit.DisconnectReason) {
+func (c *outboundCall) CloseWithReason(ctx context.Context, status CallStatus, t stats.Termination, reason livekit.DisconnectReason) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.close(ctx, nil, status, description, reason)
+	c.close(ctx, nil, status, t, reason)
 }
 
 func (c *outboundCall) closeWithTimeout(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.close(ctx, psrpc.NewErrorf(psrpc.DeadlineExceeded, "media-timeout"), callDropped, "media-timeout", livekit.DisconnectReason_UNKNOWN_REASON)
+	c.close(ctx, psrpc.NewErrorf(psrpc.DeadlineExceeded, "media-timeout"), callDropped, stats.ServerError("media-timeout"), livekit.DisconnectReason_UNKNOWN_REASON)
 }
 
 func (c *outboundCall) printStats() {
 	c.stats.Log(c.log, c.callStart)
 }
 
-func (c *outboundCall) close(ctx context.Context, err error, status CallStatus, description string, reason livekit.DisconnectReason) {
+func (c *outboundCall) close(ctx context.Context, err error, status CallStatus, t stats.Termination, reason livekit.DisconnectReason) {
 	c.closing.Break()
 	ctx = context.WithoutCancel(ctx)
 	c.stopped.Once(func() {
 		c.stats.Closed.Store(true)
-		log := c.log.WithValues("status", status, "reason", description)
+		log := c.log.WithValues("status", status, "result", string(t.Result), "reason", t.Reason)
 		defer func() {
 			c.stats.Update()
 			c.printStats()
@@ -341,7 +341,7 @@ func (c *outboundCall) close(ctx context.Context, err error, status CallStatus, 
 		// This ensures participant attributes are still available for
 		// attributes_to_headers mapping in the setHeaders callback.
 		// See: https://github.com/livekit/sip/issues/404
-		c.stopSIP(ctx, description)
+		c.stopSIP(ctx, t)
 		c.media.Close()
 
 		if r := c.lkRoom; r != nil {
@@ -367,7 +367,7 @@ func (c *outboundCall) close(ctx context.Context, err error, status CallStatus, 
 					ProjectID: c.projectID,
 					CallID:    c.state.callInfo.CallId,
 					SipCallID: c.cc.SIPCallID(),
-				}, c.state.callInfo, description)
+				}, c.state.callInfo, t.Reason)
 			}(c.tid)
 		}
 	})
@@ -388,15 +388,15 @@ func (c *outboundCall) connectSIP(ctx context.Context, tid traceid.ID) error {
 		c.log.Infow("SIP call failed", "error", err)
 
 		reportErr := err
-		status, desc, reason := callDropped, "invite-failed", livekit.DisconnectReason_UNKNOWN_REASON
+		status, term, reason := callDropped, stats.ServerError("invite-failed"), livekit.DisconnectReason_UNKNOWN_REASON
 		var e *livekit.SIPStatus
 		if errors.As(err, &e) {
 			switch int(e.Code) {
 			case int(sip.StatusTemporarilyUnavailable):
-				status, desc, reason = callUnavailable, "unavailable", livekit.DisconnectReason_USER_UNAVAILABLE
+				status, term, reason = callUnavailable, stats.ClientError("unavailable"), livekit.DisconnectReason_USER_UNAVAILABLE
 				reportErr = nil
 			case int(sip.StatusBusyHere):
-				status, desc, reason = callRejected, "busy", livekit.DisconnectReason_USER_REJECTED
+				status, term, reason = callRejected, stats.ClientError("busy"), livekit.DisconnectReason_USER_REJECTED
 				reportErr = nil
 			}
 		} else if e := (SDPError{}); errors.As(err, &e) {
@@ -404,14 +404,14 @@ func (c *outboundCall) connectSIP(ctx context.Context, tid traceid.ID) error {
 			reportErr = nil
 			err = psrpc.NewError(psrpc.FailedPrecondition, e.Err)
 			if errors.Is(e.Err, sdp.ErrNoCommonMedia) {
-				desc = "no-common-codec"
+				term = stats.ClientError("no-common-codec")
 			} else if errors.Is(e.Err, sdp.ErrNoCommonCrypto) {
-				desc = "encryption-required"
+				term = stats.ClientError("encryption-required")
 			} else {
-				desc = "sdp-error"
+				term = stats.ClientError("sdp-error")
 			}
 		}
-		c.close(ctx, reportErr, status, desc, reason)
+		c.close(ctx, reportErr, status, term, reason)
 		return err
 	}
 	c.connectMedia()
@@ -533,7 +533,7 @@ func sipResponse(ctx context.Context, tx sip.ClientTransaction, stop <-chan stru
 	}
 }
 
-func (c *outboundCall) stopSIP(ctx context.Context, reason string) {
+func (c *outboundCall) stopSIP(ctx context.Context, t stats.Termination) {
 	termCtx, cancel := context.WithCancel(context.Background()) // Do not use ctx
 	defer cancel()
 	go func() {
@@ -546,7 +546,7 @@ func (c *outboundCall) stopSIP(ctx context.Context, reason string) {
 		}
 	}()
 
-	c.mon.CallTerminate(reason)
+	c.mon.CallTerminate(t)
 	c.cc.Close(ctx)
 }
 
@@ -753,7 +753,7 @@ func (c *outboundCall) transferCall(ctx context.Context, transferTo string, head
 
 	// Give time for the peer to hang up first, but hang up ourselves if this doesn't happen within 1 second
 	time.AfterFunc(referByeTimeout, func() {
-		c.CloseWithReason(ctx, CallHangup, "call transferred", livekit.DisconnectReason_CLIENT_INITIATED)
+		c.CloseWithReason(ctx, CallHangup, stats.Success("call transferred"), livekit.DisconnectReason_CLIENT_INITIATED)
 	})
 
 	return nil

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -168,9 +168,9 @@ func (m *Monitor) Start(conf *config.Config) error {
 		Namespace:   "livekit",
 		Subsystem:   "sip",
 		Name:        "calls_terminated",
-		Help:        "Number of calls terminated by SIP bridge",
+		Help:        "Number of calls terminated by SIP bridge, labeled with result classification (success | server_error | client_error)",
 		ConstLabels: prometheus.Labels{"node_id": conf.NodeID},
-	}, []string{"dir", "to", "reason"}))
+	}, []string{"dir", "to", "result", "reason"}))
 
 	m.callsTerminationFailures = mustRegister(m, prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   "livekit",
@@ -385,10 +385,22 @@ func (c *CallMonitor) InviteAccept() {
 	c.m.inviteAccept.With(c.labels(nil)).Inc()
 }
 
-func (c *CallMonitor) InviteErrorShort(reason string) {
-	c.m.inviteErr.With(c.labelsShort(prometheus.Labels{"reason": reason, "to": "unknown"})).Inc()
+// InviteErrorShort records a SIP INVITE rejection that occurred before a call
+// object existed (no validated trunk). Writes to the legacy invite_error
+// counter (kept for back-compat) and routes through CallTerminate so the
+// unified calls_terminated counter has consistent classification.
+func (c *CallMonitor) InviteErrorShort(t Termination) {
+	c.m.inviteErr.With(c.labelsShort(prometheus.Labels{"reason": t.Reason, "to": "unknown"})).Inc()
+	c.m.callsTerminated.With(c.labelsShort(prometheus.Labels{
+		"to":     "unknown",
+		"result": string(t.Result),
+		"reason": t.Reason,
+	})).Inc()
 }
 
+// InviteError records a SIP INVITE rejection after the trunk is known. Used
+// by outbound INVITE failure paths where CallTerminate also fires for the same
+// call, so this only writes to the legacy invite_error counter.
 func (c *CallMonitor) InviteError(reason string) {
 	c.m.inviteErr.With(c.labels(prometheus.Labels{"reason": reason})).Inc()
 }
@@ -407,11 +419,14 @@ func (c *CallMonitor) CallEnd() {
 	c.m.callsActive.With(c.labels(nil)).Dec()
 }
 
-func (c *CallMonitor) CallTerminate(reason string) {
+func (c *CallMonitor) CallTerminate(t Termination) {
 	if !c.terminated.CompareAndSwap(false, true) {
 		return
 	}
-	c.m.callsTerminated.With(c.labels(prometheus.Labels{"reason": reason})).Inc()
+	c.m.callsTerminated.With(c.labels(prometheus.Labels{
+		"result": string(t.Result),
+		"reason": t.Reason,
+	})).Inc()
 }
 
 func (c *CallMonitor) CallTerminationFailure() {

--- a/pkg/stats/termination.go
+++ b/pkg/stats/termination.go
@@ -1,0 +1,36 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+type TerminationResult string
+
+const (
+	ResultSuccess     TerminationResult = "success"
+	ResultServerError TerminationResult = "server_error"
+	ResultClientError TerminationResult = "client_error"
+)
+
+type Termination struct {
+	Result TerminationResult
+	Reason string
+}
+
+func Success(reason string) Termination { return Termination{Result: ResultSuccess, Reason: reason} }
+func ServerError(reason string) Termination {
+	return Termination{Result: ResultServerError, Reason: reason}
+}
+func ClientError(reason string) Termination {
+	return Termination{Result: ResultClientError, Reason: reason}
+}


### PR DESCRIPTION
We don't have a clear way to measure SIP call reliability today. There is no call completion rate metric. This change classifies every termination at the source — the close site is where someone has the context to decide whether a failure is our fault, the customer's fault, or a successful completion. After this change, the SLI is a single metric query with a stable label, and adding a new termination path forces a classification decision via the constructor functions (Success / ServerError / ClientError) rather than a free-form string.

Changes
- New type `stats.Termination{Result, Reason}` with `Success/ServerError/ClientError` constructors. Every termination must pick one.
- `livekit_sip_calls_terminated` counter gains a `result` label (`success | server_error | client_error`) alongside existing `dir/to/reason`.
- Pre-INVITE rejections (`auth-error, flood, no-rule, quota-exceeded, no-trunk, unauthorized`) now also write to `calls_terminated` via `InviteErrorShort`, so the SLI denominator is a single metric. Legacy `invite_error` counter retained for back-compatability.
- `inboundCall.close` / `outboundCall.close` signatures take `Termination` instead of a bare `reason` string. `error bool` dropped from inbound, where `Result == ServerError` covers it.