### PR TITLE
TEL-455: support room close reason

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -966,7 +966,7 @@ func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan str
 			c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
 				info.DisconnectReason = livekit.DisconnectReason_CLIENT_INITIATED
 			})
-			c.close(ctx, callDropped, stats.Success("removed"))
+			c.close(ctx, callDropped, terminationFromRoomDisconnect(c.lkRoom.ClosedReason()))
 			return nil
 		case <-c.media.Timeout():
 			return c.mediaTimeout(ctx)

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -255,7 +255,8 @@ func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
 			c.log.Debugw("sending keep-alive")
 			c.state.ForceFlush(ctx)
 		case <-c.Disconnected():
-			c.CloseWithReason(ctx, callDropped, stats.Success("removed"), livekit.DisconnectReason_CLIENT_INITIATED)
+			term := terminationFromRoomDisconnect(c.lkRoom.ClosedReason())
+			c.CloseWithReason(ctx, callDropped, term, livekit.DisconnectReason_CLIENT_INITIATED)
 			return nil
 		case <-c.media.Timeout():
 			c.closeWithTimeout(ctx)

--- a/pkg/sip/outbound_utilities_test.go
+++ b/pkg/sip/outbound_utilities_test.go
@@ -172,6 +172,10 @@ func (r *testRoom) Closed() <-chan struct{} {
 	return r.room.Closed()
 }
 
+func (r *testRoom) ClosedReason() lksdk.DisconnectionReason {
+	return r.room.ClosedReason()
+}
+
 func (r *testRoom) Subscribed() <-chan struct{} {
 	return r.room.Subscribed()
 }

--- a/pkg/sip/participant.go
+++ b/pkg/sip/participant.go
@@ -18,8 +18,31 @@ import (
 	"time"
 
 	"github.com/livekit/protocol/livekit"
+	lksdk "github.com/livekit/server-sdk-go/v2"
 	"github.com/livekit/sipgo/sip"
+
+	"github.com/livekit/sip/pkg/stats"
 )
+
+// terminationFromRoomDisconnect classifies a call termination triggered by
+// the LiveKit room closing. The reason comes from lksdk's
+// OnDisconnectedWithReason callback. Clean leaves (customer ended the call
+// or removed the participant) count as success; connection failures and
+// unknown causes count as server_error.
+func terminationFromRoomDisconnect(reason lksdk.DisconnectionReason) stats.Termination {
+	switch reason {
+	case lksdk.LeaveRequested, lksdk.RoomClosed, lksdk.ParticipantRemoved:
+		return stats.Success("removed")
+	case lksdk.Failed:
+		return stats.ServerError("room-failed")
+	default:
+		// UserUnavailable, RejectedByUser, DuplicateIdentity, OtherReason,
+		// or empty (no reason reported by SDK). Conservative default —
+		// surface as server_error so the SLI doesn't silently absorb LK-side
+		// issues.
+		return stats.ServerError("room-disconnected")
+	}
+}
 
 const (
 	// maxCallDuration sets a global max call duration.

--- a/pkg/sip/room.go
+++ b/pkg/sip/room.go
@@ -148,6 +148,7 @@ type ParticipantInfo struct {
 type RoomInterface interface {
 	Connect(ctx context.Context, conf *config.Config, rconf RoomConfig) error
 	Closed() <-chan struct{}
+	ClosedReason() lksdk.DisconnectionReason
 	Subscribed() <-chan struct{}
 	Room() *lksdk.Room
 	Subscribe()
@@ -170,19 +171,20 @@ func DefaultGetRoomFunc(log logger.Logger, st *RoomStats) RoomInterface {
 }
 
 type Room struct {
-	log        logger.Logger
-	roomLog    logger.Logger // deferred logger
-	room       *lksdk.Room
-	mix        *mixer.Mixer
-	out        *msdk.SwitchWriter
-	outDtmf    atomic.Pointer[dtmf.Writer]
-	p          ParticipantInfo
-	ready      core.Fuse
-	subscribe  atomic.Bool
-	subscribed core.Fuse
-	stopped    core.Fuse
-	closed     core.Fuse
-	stats      *RoomStats
+	log          logger.Logger
+	roomLog      logger.Logger // deferred logger
+	room         *lksdk.Room
+	mix          *mixer.Mixer
+	out          *msdk.SwitchWriter
+	outDtmf      atomic.Pointer[dtmf.Writer]
+	p            ParticipantInfo
+	ready        core.Fuse
+	subscribe    atomic.Bool
+	subscribed   core.Fuse
+	stopped      core.Fuse
+	closed       core.Fuse
+	closedReason atomic.Pointer[lksdk.DisconnectionReason]
+	stats        *RoomStats
 }
 
 type ParticipantConfig struct {
@@ -241,6 +243,19 @@ func (r *Room) Closed() <-chan struct{} {
 		return nil
 	}
 	return r.stopped.Watch()
+}
+
+// ClosedReason returns the LiveKit disconnect reason once Closed() has fired.
+// Returns an empty string if the room hasn't disconnected or no reason was
+// reported.
+func (r *Room) ClosedReason() lksdk.DisconnectionReason {
+	if r == nil {
+		return ""
+	}
+	if p := r.closedReason.Load(); p != nil {
+		return *p
+	}
+	return ""
 }
 
 func (r *Room) Subscribed() <-chan struct{} {
@@ -385,7 +400,8 @@ func (r *Room) Connect(ctx context.Context, conf *config.Config, rconf RoomConfi
 				r.roomLog.Infow("track unsubscribed", "participant", rp.Identity(), "participantID", rp.SID(), "trackID", track.ID(), "trackName", pub.Name())
 			},
 		},
-		OnDisconnected: func() {
+		OnDisconnectedWithReason: func(reason lksdk.DisconnectionReason) {
+			r.closedReason.Store(&reason)
 			r.stopped.Break()
 		},
 	}


### PR DESCRIPTION
There are multiple reasons a room might be closed, some of which should be treated as server errors.