### PR TITLE
TEL-553: fix noisy srtp error log

### DIFF
--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -694,7 +694,7 @@ func (p *MediaPort) SetConfig(c *MediaConf) error {
 		err  error
 	)
 	if c.Crypto != nil {
-		sess, err = srtp.NewSession(p.log, p.port, c.Crypto)
+		sess, err = srtp.NewSession(p.log, &srtpConn{Conn: p.port}, c.Crypto)
 	} else {
 		sess = rtp.NewSession(p.log, p.port)
 	}

--- a/pkg/sip/srtp_conn.go
+++ b/pkg/sip/srtp_conn.go
@@ -1,0 +1,47 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sip
+
+import (
+	"errors"
+	"io"
+	"net"
+	"sync/atomic"
+)
+
+// srtpConn wraps the UDP conn passed to a pion SRTP session and translates
+// net.ErrClosed from Read into io.EOF after Close has been called. pion/srtp's
+// read goroutine logs every non-EOF read error at ERROR level (see pion/srtp/v3
+// session.go), and the only way to wake that goroutine for shutdown is to close
+// the conn, which produces net.ErrClosed on every normal call teardown.
+// Translating to io.EOF lets pion's existing EOF filter swallow the message
+// without affecting any other error path.
+type srtpConn struct {
+	net.Conn
+	closing atomic.Bool
+}
+
+func (c *srtpConn) Read(b []byte) (int, error) {
+	n, err := c.Conn.Read(b)
+	if err != nil && c.closing.Load() && errors.Is(err, net.ErrClosed) {
+		return n, io.EOF
+	}
+	return n, err
+}
+
+func (c *srtpConn) Close() error {
+	c.closing.Store(true)
+	return c.Conn.Close()
+}

--- a/pkg/sip/srtp_conn_test.go
+++ b/pkg/sip/srtp_conn_test.go
@@ -1,0 +1,40 @@
+// Copyright 2026 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sip
+
+import (
+	"io"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSRTPConn_TranslatesErrClosedToEOFAfterClose(t *testing.T) {
+	udp, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv6loopback})
+	require.NoError(t, err)
+
+	c := &srtpConn{Conn: udp}
+
+	go func() {
+		_ = c.Close()
+	}()
+
+	buf := make([]byte, 16)
+	_, err = c.Read(buf)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, io.EOF, "Read after Close should return io.EOF, got %v", err)
+}


### PR DESCRIPTION
When a SIP call ends, MediaPort.Close() closes the underlying UDP conn, and the read goroutine wakes up with net.ErrClosed ("use of closed network connection"), which is a perfectly normal teardown, but logged as ERROR.