### PR TITLE
Remove cache from 'Release to Docker' workflow as unused

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 LiveKit, Inc.
+# Copyright 2026 LiveKit, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,16 +27,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/go/bin
-            ~/bin/protoc
-            ~/.cache
-          key: ${{ runner.os }}-sip-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-sip
 
       - name: Docker metadata
         id: docker-md


### PR DESCRIPTION
The latest execution of this workflow did not leverage a cache - https://github.com/livekit/sip/actions/runs/24797926357/job/72572555591#step:3:15
> Cache not found for input keys: Linux-sip-593514dd3523853c5ce90ca9cdc53675ba051e676e5c808c8637493462e4e6d7, Linux-sip

Due to frequent cache creations from other workflows, caches are often evicted as noted on https://github.com/livekit/sip/actions/caches
> Approaching total cache storage limit (10.27 GB of 10 GB Used)
> Least recently used caches will be automatically evicted to limit the total cache storage to 10 GB

Along with the infrequent executions of the 'Release to Docker' workflow, any cache created would likely be evicted before it could be utilized. So, proposing removing the cache step from the 'Release to Docker' workflow as unused.

Closes https://github.com/livekit/sip/pull/433.