### PR TITLE
TEL-562: improve correctness of media timeout

### DIFF
--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -501,10 +501,15 @@ func (p *MediaPort) timeoutLoop(timeoutCallback func()) {
 			lastPacketTime = time.Unix(0, nano)
 		}
 
-		// First timeout could be different. Usually it's longer to allow for a call setup.
-		// In some cases it could be shorter (e.g. when we notice an issue with signaling and suspect media will fail).
-		// Initial mode: no packet has arrived since the timeout was last enabled or reset.
-		isInitial := lastPacketTime.Before(startTime)
+		generalTimeout := p.opts.MediaTimeout
+		if ptr := p.timeoutGeneral.Load(); ptr != nil {
+			generalTimeout = *ptr
+		}
+
+		// Initial mode: no media has ever been received on this port. Once a single
+		// RTP packet arrives, we switch to the general window regardless of any
+		// subsequent SetTimeout re-arming the startTime.
+		isInitial := lastPacketTime.IsZero()
 		var (
 			deadline time.Time
 			timeout  time.Duration
@@ -516,19 +521,21 @@ func (p *MediaPort) timeoutLoop(timeoutCallback func()) {
 			}
 			deadline = startTime.Add(timeout)
 		} else {
-			timeout = p.opts.MediaTimeout
-			if ptr := p.timeoutGeneral.Load(); ptr != nil {
-				timeout = *ptr
-			}
+			timeout = generalTimeout
 			deadline = lastPacketTime.Add(timeout)
 		}
 		remaining := time.Until(deadline)
+
+		var sinceLast time.Duration
+		if !lastPacketTime.IsZero() {
+			sinceLast = time.Since(lastPacketTime)
+		}
 
 		if verbose {
 			log := p.log.WithValues(
 				"packets", p.packetCount.Load(),
 				"sinceStart", time.Since(startTime),
-				"sinceLast", time.Since(lastPacketTime),
+				"sinceLast", sinceLast,
 				"remaining", remaining,
 				"timeout", timeout,
 				"isInitial", isInitial,
@@ -544,14 +551,17 @@ func (p *MediaPort) timeoutLoop(timeoutCallback func()) {
 			p.log.Infow("triggering media timeout",
 				"packets", p.packetCount.Load(),
 				"sinceStart", time.Since(startTime),
-				"sinceLast", time.Since(lastPacketTime),
+				"sinceLast", sinceLast,
 				"timeout", timeout,
 				"isInitial", isInitial,
 			)
 			timeoutCallback()
 			return
 		}
-		timer.Reset(remaining)
+		// Cap the wake-up at the general timeout so packet arrivals during a long
+		// initial window get observed within one general interval, instead of
+		// having to wait out the full initial deadline.
+		timer.Reset(min(remaining, generalTimeout))
 	}
 }
 

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -486,7 +486,7 @@ func TestMediaTimeout(t *testing.T) {
 		}
 	})
 
-	t.Run("reset timeout", func(t *testing.T) {
+	t.Run("reset timeout after media", func(t *testing.T) {
 		m1, m2 := newMediaPair(t, &MediaOptions{
 			MediaTimeoutInitial: initial,
 			MediaTimeout:        timeout,
@@ -506,12 +506,36 @@ func TestMediaTimeout(t *testing.T) {
 			}
 		}
 
+		// Once media has flowed, SetTimeout does not re-enter the initial window —
+		// the general timeout applies relative to the last received RTP packet.
+		// Last packet arrived at most timeout/2 ago, so the timeout should fire
+		// within ~timeout from now, well before initial would elapse.
+		m1.SetTimeout(initial, timeout)
+
+		select {
+		case <-time.After(timeout + dt):
+			t.Fatal("timeout didn't trigger")
+		case <-m1.Timeout():
+		}
+	})
+
+	t.Run("reset timeout before any media", func(t *testing.T) {
+		m1, _ := newMediaPair(t, &MediaOptions{
+			MediaTimeoutInitial: initial,
+			MediaTimeout:        timeout,
+		}, nil)
+		m1.EnableTimeout(true)
+
+		// No media has ever arrived. SetTimeout re-arms startTime, and since the
+		// port has never seen an RTP packet, the new initial window applies from
+		// the moment of the SetTimeout call.
+		time.Sleep(initial / 2)
 		m1.SetTimeout(initial, timeout)
 
 		targ := time.Now().Add(initial)
 		select {
 		case <-m1.Timeout():
-			t.Fatal("initial timeout ignored")
+			t.Fatal("initial timeout fired too early")
 		case <-time.After(initial / 2):
 		}
 


### PR DESCRIPTION
Three improvements:
1. When `lastPacketTime` was zero (no packet ever received), `time.Since(lastPacketTime)` overflowed `time.Duration` and logged as `~9.22e9s`. Now `sinceLast` is `0` when there has been no packet.
2. `sinceLast` exceeding the general timeout when `isInitial:false`. When media flowed briefly during the initial window and then stopped, the loop slept until the full initial deadline (e.g. 30s) before re-evaluating, at which point `lastPacketTime` was already older than the general timeout (e.g. `sinceLast=20.3s` with `timeout=15`). Fixed by capping the timer arm at the general timeout. This is not a regression. The previous media timeout mechanism has the same problem, e.g. last packet arrives at 9.7s then stopped. The first ticker triggers at 15s and then again at 15s. The "real" timeout is 20.3s.
3. `isInitial` flipping back to `true` mid-call after `SetTimeout`. `isInitial := lastPacketTime.Before(startTime)` was relative to the most recently re-armed `startTime`, so the no-ACK fallback `(SetTimeout(min(3s, MediaTimeoutInitial), MediaTimeout))` caused calls that had already received RTP to be re-classified as initial and killed by the shortened 3s window, producing logs like `isInitial:true, packets:38, sinceLast:5.16s`. Changed to `isInitial := lastPacketTime.IsZero()`. `isInitial` now means "no media has ever been received on this port." Policy change: once media is flowing, the no-ACK fallback no longer triggers the 3s shortcut. The call is killed only after the general 15s window of silence from the last packet. Signaling faults no longer aggressively tear down calls whose media is healthy.

datadog log: https://app.datadoghq.com/logs?query=%22triggering%20media%20timeout%22%20region%3Aofrankfurt1b&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40sinceLast%2C%40isInitial%2Cimage_tag%2C%40sinceStart%2C%40timeout&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1778596320000&to_ts=1778610600000&live=false