### PR TITLE
feat(tls): make ALPN protocols configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -66,7 +66,7 @@ type TLSConfig struct {
 	// ALPNProtocols is an optional list of ALPN protocol names for TLS negotiation.
 	// If not provided, defaults to ["sip"]. Set to an empty list to disable ALPN.
 	// Some providers (e.g. Meta) reject the "sip" ALPN and require it to be disabled.
-	ALPNProtocols *[]string `yaml:"alpn"`
+	ALPNProtocols []string `yaml:"alpn"`
 }
 
 type TCPConfig struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,6 +62,11 @@ type TLSConfig struct {
 	// If not provided, Go's secure defaults are used.
 	// Note: Only applies to TLS 1.0-1.2; TLS 1.3 cipher suites are not configurable.
 	CipherSuites []string `yaml:"cipher_suites"`
+
+	// ALPNProtocols is an optional list of ALPN protocol names for TLS negotiation.
+	// If not provided, defaults to ["sip"]. Set to an empty list to disable ALPN.
+	// Some providers (e.g. Meta) reject the "sip" ALPN and require it to be disabled.
+	ALPNProtocols *[]string `yaml:"alpn"`
 }
 
 type TCPConfig struct {

--- a/pkg/sip/service.go
+++ b/pkg/sip/service.go
@@ -263,7 +263,7 @@ func (s *Service) Start() error {
 			}()
 		}
 		tlsConf = &tls.Config{
-			NextProtos:   []string{"sip"},
+			NextProtos:   tlsALPNProtocols(tconf.ALPNProtocols),
 			Certificates: certs,
 			KeyLogWriter: keyLog,
 		}

--- a/pkg/sip/tls.go
+++ b/pkg/sip/tls.go
@@ -60,6 +60,19 @@ func ConfigureTLS(c *tls.Config) {
 	}
 }
 
+// defaultALPNProtocols is the default set of ALPN protocols for SIP over TLS.
+var defaultALPNProtocols = []string{"sip"}
+
+// tlsALPNProtocols returns the ALPN protocols to use for TLS negotiation.
+// If alpn is nil (not configured), it returns the default ["sip"].
+// If alpn is non-nil, it returns the configured value (which may be empty to disable ALPN).
+func tlsALPNProtocols(alpn *[]string) []string {
+	if alpn == nil {
+		return defaultALPNProtocols
+	}
+	return *alpn
+}
+
 // parseCipherSuites parses cipher suite names to uint16 IDs.
 // Logs a warning for each insecure cipher suite configured.
 func parseCipherSuites(log logger.Logger, suites []string) ([]uint16, error) {

--- a/pkg/sip/tls.go
+++ b/pkg/sip/tls.go
@@ -66,11 +66,11 @@ var defaultALPNProtocols = []string{"sip"}
 // tlsALPNProtocols returns the ALPN protocols to use for TLS negotiation.
 // If alpn is nil (not configured), it returns the default ["sip"].
 // If alpn is non-nil, it returns the configured value (which may be empty to disable ALPN).
-func tlsALPNProtocols(alpn *[]string) []string {
+func tlsALPNProtocols(alpn []string) []string {
 	if alpn == nil {
 		return defaultALPNProtocols
 	}
-	return *alpn
+	return alpn
 }
 
 // parseCipherSuites parses cipher suite names to uint16 IDs.

--- a/pkg/sip/tls_test.go
+++ b/pkg/sip/tls_test.go
@@ -136,3 +136,28 @@ func TestParseTLSVersion(t *testing.T) {
 		require.Contains(t, err.Error(), "unknown TLS version: TLS 1.2")
 	})
 }
+
+func TestTLSALPNProtocols(t *testing.T) {
+	t.Run("nil returns default sip", func(t *testing.T) {
+		protos := tlsALPNProtocols(nil)
+		require.Equal(t, []string{"sip"}, protos)
+	})
+
+	t.Run("empty slice disables ALPN", func(t *testing.T) {
+		empty := []string{}
+		protos := tlsALPNProtocols(&empty)
+		require.Empty(t, protos)
+	})
+
+	t.Run("custom protocols", func(t *testing.T) {
+		custom := []string{"h2", "http/1.1"}
+		protos := tlsALPNProtocols(&custom)
+		require.Equal(t, []string{"h2", "http/1.1"}, protos)
+	})
+
+	t.Run("single custom protocol", func(t *testing.T) {
+		custom := []string{"sip"}
+		protos := tlsALPNProtocols(&custom)
+		require.Equal(t, []string{"sip"}, protos)
+	})
+}

--- a/pkg/sip/tls_test.go
+++ b/pkg/sip/tls_test.go
@@ -145,19 +145,19 @@ func TestTLSALPNProtocols(t *testing.T) {
 
 	t.Run("empty slice disables ALPN", func(t *testing.T) {
 		empty := []string{}
-		protos := tlsALPNProtocols(&empty)
+		protos := tlsALPNProtocols(empty)
 		require.Empty(t, protos)
 	})
 
 	t.Run("custom protocols", func(t *testing.T) {
 		custom := []string{"h2", "http/1.1"}
-		protos := tlsALPNProtocols(&custom)
+		protos := tlsALPNProtocols(custom)
 		require.Equal(t, []string{"h2", "http/1.1"}, protos)
 	})
 
 	t.Run("single custom protocol", func(t *testing.T) {
 		custom := []string{"sip"}
-		protos := tlsALPNProtocols(&custom)
+		protos := tlsALPNProtocols(custom)
 		require.Equal(t, []string{"sip"}, protos)
 	})
 }


### PR DESCRIPTION
## Summary

Fixes: #685 

Adds a configurable `alpn` field to `TLSConfig` to allow operators to control the ALPN protocols sent during TLS negotiation. This fixes  outbound TLS calls to providers like Meta (`wa.meta.vc`) that reject the `sip` ALPN with `tls: no application protocol`.

## Backward Compatibility

Existing configurations without the `alpn` field continue to send `["sip"]` as before.

## Usage

```yaml
# Default behavior (equivalent to not setting alpn at all):
tls:
  alpn: ["sip"]

# Disable ALPN for Meta and other providers that reject it:
tls:
  alpn: []

# Custom ALPN protocols:
tls:
  alpn: ["h2", "http/1.1"]
```

## Testing

### Unit tests

- Added `TestTLSALPNProtocols` covering: nil (default `["sip"]`), empty slice (disables ALPN), custom values, and single protocol.

### Integration test: outbound call to Meta (`wa.meta.vc`)

Reproduced the scenario described in the issue ticket (#685) end-to-end:

1. Created an Azure VM with the required open ports and a TLS-enabled domain.
2. Deployed a Docker Compose stack with a LiveKit SIP image built from this branch, configured with `alpn: []`.

<details>
<summary>Docker Compose configuration (Ansible template)</summary>

```yaml
services:
  redis:
    image: redis
    restart: unless-stopped
    volumes:
      - redis-data:/data
    ports:
      - "6379:6379"

  livekit:
    image: livekit/livekit-server:master
    restart: unless-stopped
    command: >-
      --redis-host localhost:6379
      --bind {{ livekit_server_bind_address }}
      --keys "{{ livekit_api_key }}: {{ livekit_api_secret }}"
      --port {{ livekit_server_port }}
    network_mode: host
    depends_on:
      redis:
        condition: service_started

  sip:
    image: {{ livekit_sip_image }}
    restart: unless-stopped
    network_mode: host
    depends_on:
      livekit:
        condition: service_started
    environment:
      SIP_CONFIG_BODY: |
        api_key: {{ livekit_api_key | to_json }}
        api_secret: {{ livekit_api_secret | to_json }}
        ws_url: {{ ws_url | to_json }}
        redis:
          address: {{ redis_address | to_json }}
        sip_port: {{ sip_udp_port }}
        rtp_port: {{ rtp_udp_start }}-{{ rtp_udp_end }}
        use_external_ip: true
        sip_hostname: {{ livekit_fqdn | to_json }}
        tls:
          port: {{ sip_tls_port }}
          certs:
          - cert_file: "/etc/letsencrypt/live/{{ livekit_fqdn }}/fullchain.pem"
            key_file: "/etc/letsencrypt/live/{{ livekit_fqdn }}/privkey.pem"
          alpn: []
          key_log: /var/log/livekit/sip_tls_keys.log
        logging:
          level: debug
    volumes:
      - /etc/letsencrypt/live/{{ livekit_fqdn }}/fullchain.pem:/etc/letsencrypt/live/{{ livekit_fqdn }}/fullchain.pem:ro
      - /etc/letsencrypt/live/{{ livekit_fqdn }}/privkey.pem:/etc/letsencrypt/live/{{ livekit_fqdn }}/privkey.pem:ro
      - /var/log/livekit:/var/log/livekit

volumes:
  redis-data:
```

</details>

3. Created a SIP participant — the outbound call to Meta succeeded.

### Result

The full SIP call flow completed successfully: `INVITE` → `407 Proxy Authentication Required` → re-`INVITE` with credentials → `100 Trying` → `180 Ringing` → `200 OK` → `ACK` → media exchange → `BYE` → `200 OK`.

<img width="949" height="366" alt="image" src="https://github.com/user-attachments/assets/b76e8561-3787-48e4-9dbf-dcb1c8b6b325" />

<details>
<summary>Captured SIP messages (redacted)</summary>

#### 1. Initial INVITE

```
INVITE sip:+<redacted-to-number>@wa.meta.vc;transport=tls SIP/2.0
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;branch=<redacted>;alias
CSeq: 1 INVITE
Call-ID: <redacted>
Content-Length: 671
To: <sip:+<redacted-to-number>@wa.meta.vc;transport=tls>
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>:5061;transport=tls>;tag=<redacted>
Contact: <sip:<redacted-vm-fqdn>:5061;transport=tls>
Content-Type: application/sdp
Allow: INVITE, ACK, CANCEL, BYE, NOTIFY, REFER, MESSAGE, OPTIONS, INFO, SUBSCRIBE
Max-Forwards: 70

v=0
o=- 4124614972148466078 4124614972148466078 IN IP4 <redacted-vm-ip>
s=LiveKit
c=IN IP4 <redacted-vm-ip>
t=0 0
m=audio 18560 RTP/SAVP 9 0 8 101
a=rtpmap:9 G722/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-16
a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:<redacted>
a=crypto:2 AES_CM_128_HMAC_SHA1_32 inline:<redacted>
a=crypto:3 AES_256_CM_HMAC_SHA1_80 inline:<redacted>
a=crypto:4 AES_256_CM_HMAC_SHA1_32 inline:<redacted>
a=ptime:20
a=sendrecv
```

#### 2. 407 Proxy Authentication Required

```
SIP/2.0 407 Proxy Authentication Required
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;received=<redacted-ipv6>;branch=<redacted>;alias
Call-ID: <redacted>
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>>;tag=<redacted>
To: <sip:+<redacted-to-number>@wa.meta.vc>;tag=<redacted>
CSeq: 1 INVITE
Proxy-Authenticate: Digest realm="wa.meta.vc",nonce="<redacted>",opaque="<redacted>",algorithm=SHA-256,qop="auth"
Proxy-Authenticate: Digest realm="wa.meta.vc",nonce="<redacted>",opaque="<redacted>",algorithm=MD5,qop="auth"
Content-Length: 0
```

#### 3. ACK (to 407)

```
ACK sip:+<redacted-to-number>@wa.meta.vc;transport=tls SIP/2.0
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;branch=<redacted>;alias
Max-Forwards: 70
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>:5061;transport=tls>;tag=<redacted>
To: <sip:+<redacted-to-number>@wa.meta.vc>;tag=<redacted>
Call-ID: <redacted>
CSeq: 1 ACK
Contact: <sip:<redacted-vm-fqdn>:5061;transport=tls>
Content-Length: 0
```

#### 4. Re-INVITE with Proxy-Authorization

```
INVITE sip:+<redacted-to-number>@wa.meta.vc;transport=tls SIP/2.0
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;branch=<redacted>;alias
CSeq: 2 INVITE
Call-ID: <redacted>
Content-Length: 671
To: <sip:+<redacted-to-number>@wa.meta.vc;transport=tls>
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>:5061;transport=tls>;tag=<redacted>
Contact: <sip:<redacted-vm-fqdn>:5061;transport=tls>
Content-Type: application/sdp
Allow: INVITE, ACK, CANCEL, BYE, NOTIFY, REFER, MESSAGE, OPTIONS, INFO, SUBSCRIBE
Proxy-Authorization: Digest username="<redacted-from-number>", realm="wa.meta.vc", nonce="<redacted>", uri="sip:+<redacted-to-number>@wa.meta.vc", algorithm=SHA-256, cnonce="<redacted>", opaque="<redacted>", qop=auth, nc=<redacted>
Max-Forwards: 70

v=0
o=- 4124614972148466078 4124614972148466078 IN IP4 <redacted-vm-ip>
s=LiveKit
c=IN IP4 <redacted-vm-ip>
t=0 0
m=audio 18560 RTP/SAVP 9 0 8 101
a=rtpmap:9 G722/8000
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=rtpmap:101 telephone-event/8000
a=fmtp:101 0-16
a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:<redacted>
a=crypto:2 AES_CM_128_HMAC_SHA1_32 inline:<redacted>
a=crypto:3 AES_256_CM_HMAC_SHA1_80 inline:<redacted>
a=crypto:4 AES_256_CM_HMAC_SHA1_32 inline:<redacted>
a=ptime:20
a=sendrecv
```

#### 5. 100 Trying

```
SIP/2.0 100 Trying
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;received=<redacted-ipv6>;branch=<redacted>;alias
Call-ID: <redacted>
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>>;tag=<redacted>
To: <sip:+<redacted-to-number>@wa.meta.vc>
CSeq: 2 INVITE
Content-Length: 0
```

#### 6. 180 Ringing

```
SIP/2.0 180 Ringing
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;received=<redacted-ipv6>;branch=<redacted>;alias
Record-Route: <sip:<redacted-upstream-proxy>:8191;transport=tls;lr>
Record-Route: <sip:wa.meta.vc;transport=tls;lr>
Call-ID: <redacted>
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>>;tag=<redacted>
To: <sip:+<redacted-to-number>@wa.meta.vc>;tag=<redacted>
CSeq: 2 INVITE
Contact: <sip:+<redacted-to-number>@wa.meta.vc;transport=tls;ob;X-FB-Sip-Smc-Tier=collaboration.sip_gateway.sip.prod>
Allow: INVITE, ACK, BYE, CANCEL, NOTIFY, OPTIONS
X-FB-External-Domain: wa.meta.vc
Server: Facebook SipGateway
Content-Length: 0
```

#### 7. 200 OK (with SDP answer)

```
SIP/2.0 200 OK
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;received=<redacted-ipv6>;branch=<redacted>;alias
Record-Route: <sip:<redacted-upstream-proxy>:8191;transport=tls;lr>
Record-Route: <sip:wa.meta.vc;transport=tls;lr>
Call-ID: <redacted>
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>>;tag=<redacted>
To: <sip:+<redacted-to-number>@wa.meta.vc>;tag=<redacted>
CSeq: 2 INVITE
Contact: <sip:+<redacted-to-number>@wa.meta.vc;transport=tls;ob;X-FB-Sip-Smc-Tier=collaboration.sip_gateway.sip.prod>
Allow: INVITE, ACK, BYE, CANCEL, NOTIFY, OPTIONS
Supported: timer
X-FB-External-Domain: wa.meta.vc
Server: Facebook SipGateway
x-wa-meta-wacid: <redacted>
x-wa-meta-user-id: <redacted>
x-wa-meta-country-code: AR
Content-Type: application/sdp
Content-Length: 497

v=0
o=- 1778635760917 2 IN IP4 <redacted-local-ip>
s=-
t=0 0
a=group:BUNDLE audio
a=msid-semantic: WMS <redacted-msid>
m=audio 3480 RTP/SAVP 0 101
c=IN IP4 <redacted-remote-ip>
a=rtcp:9 IN IP4 <redacted-local-ip>
a=mid:audio
a=sendrecv
a=msid:<redacted-msid> WhatsAppTrack1
a=rtcp-mux
a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:<redacted>
a=rtpmap:0 PCMU/8000
a=rtpmap:101 telephone-event/8000
a=ssrc:<redacted> cname:WhatsAppAudioStream1
```

#### 8. ACK (to 200 OK)

```
ACK sip:+<redacted-to-number>@wa.meta.vc;transport=tls;ob;X-FB-Sip-Smc-Tier=collaboration.sip_gateway.sip.prod SIP/2.0
Via: SIP/2.0/TLS <redacted-vm-ip>:45116;branch=<redacted>;alias
Route: <sip:wa.meta.vc;transport=tls;lr>
Route: <sip:<redacted-upstream-proxy>:8191;transport=tls;lr>
Max-Forwards: 70
From: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>:5061;transport=tls>;tag=<redacted>
To: <sip:+<redacted-to-number>@wa.meta.vc>;tag=<redacted>
Call-ID: <redacted>
CSeq: 2 ACK
Contact: <sip:<redacted-vm-fqdn>:5061;transport=tls>
Content-Length: 0
```

#### 9. BYE (from Meta)

```
BYE sip:<redacted-vm-fqdn>:5061;transport=tls SIP/2.0
Via: SIP/2.0/TLS [<redacted-ipv6>]:8082;rport;branch=<redacted>;alias
Via: SIP/2.0/TLS [<redacted-ipv6>]:5061;branch=<redacted>
Via: SIP/2.0/TLS [<redacted-ipv6>]:59029;rport=59029;received=<redacted-ipv6>;branch=<redacted>;alias
Max-Forwards: 69
From: <sip:+<redacted-to-number>@wa.meta.vc>;tag=<redacted>
To: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>>;tag=<redacted>
Call-ID: <redacted>
CSeq: 23193 BYE
X-FB-External-Domain: wa.meta.vc
Allow: INVITE, ACK, BYE, CANCEL, NOTIFY, OPTIONS
User-Agent: Facebook SipGateway
x-wa-meta-wacid: <redacted>
x-wa-meta-call-duration: 2
x-wa-meta-user-id: <redacted>
x-wa-meta-country-code: AR
Content-Length: 0
```

#### 10. 200 OK (to BYE)

```
SIP/2.0 200 OK
Via: SIP/2.0/TLS [<redacted-ipv6>]:8082;rport=51056;branch=<redacted>;alias;received=<redacted-ipv4>
Via: SIP/2.0/TLS [<redacted-ipv6>]:5061;branch=<redacted>
Via: SIP/2.0/TLS [<redacted-ipv6>]:59029;rport=59029;received=<redacted-ipv6>;branch=<redacted>;alias
From: <sip:+<redacted-to-number>@wa.meta.vc>;tag=<redacted>
To: "<redacted-from-number>" <sip:<redacted-from-number>@<redacted-vm-fqdn>>;tag=<redacted>
Call-ID: <redacted>
CSeq: 23193 BYE
Content-Length: 0
```

</details>

### Known issue

After the ALPN issue was resolved, calls consistently progressed past TLS and SIP digest authentication. Some calls intermittently failed with a `403 SDP Validation Error: Provided SDP is invalid` from Meta.  Retrying the same call typically succeeds. It's unclear whether the invalid SDP originates from LiveKit's offer or from Meta's validation logic. This needs further investigation and should be tracked separately from this ALPN change.
