### PR TITLE
Allow ignoring local IP in SDP and enable symmetric mode

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -106,10 +106,11 @@ type Config struct {
 	MediaUseExternalIP bool   `yaml:"media_use_external_ip"`
 	MediaNAT1To1IP     string `yaml:"media_nat_1_to_1_ip"`
 
-	MediaTimeout        time.Duration   `yaml:"media_timeout"`
-	MediaTimeoutInitial time.Duration   `yaml:"media_timeout_initial"`
-	SymmetricRTP        bool            `yaml:"symmetric_rtp"`
-	Codecs              map[string]bool `yaml:"codecs"`
+	MediaTimeout         time.Duration   `yaml:"media_timeout"`
+	MediaTimeoutInitial  time.Duration   `yaml:"media_timeout_initial"`
+	SymmetricRTP         bool            `yaml:"symmetric_rtp"`
+	IgnoreLocalAddrInSDP bool            `yaml:"ignore_local_addr_in_sdp"` // enable symmetric RTP if local IP is specified in SDP
+	Codecs               map[string]bool `yaml:"codecs"`
 
 	// HideInboundPort controls how SIP endpoint responds to unverified inbound requests.
 	// Setting it to true makes SIP server silently drop INVITE requests if it gets a negative Auth or Dispatch response.

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1042,15 +1042,16 @@ func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, mconf *sipM
 	logSignalChanges := false
 	logSignalChanges, _ = strconv.ParseBool(featureFlags[signalLoggingFeatureFlag])
 	mp, err := NewMediaPort(tid, c.log(), c.mon, &MediaOptions{
-		IP:                  c.s.sconf.MediaIP,
-		Ports:               conf.RTPPort,
-		MediaTimeoutInitial: c.s.conf.MediaTimeoutInitial,
-		MediaTimeout:        mconf.MediaTimeout,
-		SymmetricRTP:        conf.SymmetricRTP,
-		EnableJitterBuffer:  c.jitterBuf,
-		LogSignalChanges:    logSignalChanges,
-		Stats:               &c.stats.Port,
-		NoInputResample:     !RoomResample,
+		IP:                   c.s.sconf.MediaIP,
+		Ports:                conf.RTPPort,
+		MediaTimeoutInitial:  c.s.conf.MediaTimeoutInitial,
+		MediaTimeout:         mconf.MediaTimeout,
+		SymmetricRTP:         conf.SymmetricRTP,
+		IgnoreLocalAddrInSDP: c.s.conf.IgnoreLocalAddrInSDP,
+		EnableJitterBuffer:   c.jitterBuf,
+		LogSignalChanges:     logSignalChanges,
+		Stats:                &c.stats.Port,
+		NoInputResample:      !RoomResample,
 	}, RoomSampleRate)
 	if err != nil {
 		return nil, err

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -198,18 +198,28 @@ type UDPConn interface {
 	WriteToUDPAddrPort(b []byte, addr netip.AddrPort) (int, error)
 }
 
-func newUDPConn(log logger.Logger, conn UDPConn, symmetricRTP bool) *udpConn {
-	return &udpConn{UDPConn: conn, log: log, stopped: make(chan struct{}), symmetricRTP: symmetricRTP}
+func newUDPConn(log logger.Logger, conn UDPConn, symmetric bool) *udpConn {
+	c := &udpConn{
+		UDPConn: conn,
+		log:     log,
+		stopped: make(chan struct{}),
+	}
+	c.symmetric.Store(symmetric)
+	return c
 }
 
 type udpConn struct {
 	UDPConn
-	stopping     core.Fuse
-	stopped      chan struct{}
-	log          logger.Logger
-	symmetricRTP bool
-	src          atomic.Pointer[netip.AddrPort]
-	dst          atomic.Pointer[netip.AddrPort]
+	stopping  core.Fuse
+	stopped   chan struct{}
+	log       logger.Logger
+	symmetric atomic.Bool // send packets to the same address we receive them from
+	src       atomic.Pointer[netip.AddrPort]
+	dst       atomic.Pointer[netip.AddrPort]
+}
+
+func (c *udpConn) SetSymmetric(enabled bool) {
+	c.symmetric.Store(enabled)
 }
 
 func (c *udpConn) GetSrc() (netip.AddrPort, bool) {
@@ -240,7 +250,7 @@ func (c *udpConn) Read(b []byte) (n int, err error) {
 	} else if *prev != addr {
 		c.log.Infow("changing media source", "addr", addr.String())
 	}
-	if c.symmetricRTP {
+	if c.symmetric.Load() {
 		dst := c.dst.Load()
 		if dst == nil || !dst.IsValid() || *dst != addr {
 			c.SetDst(addr)
@@ -305,16 +315,17 @@ type MediaConf struct {
 }
 
 type MediaOptions struct {
-	IP                  netip.Addr
-	Ports               rtcconfig.PortRange
-	MediaTimeoutInitial time.Duration
-	MediaTimeout        time.Duration
-	SymmetricRTP        bool
-	Stats               *PortStats
-	EnableJitterBuffer  bool
-	NoInputResample     bool
-	IgnorePreanswerData bool
-	LogSignalChanges    bool
+	IP                   netip.Addr
+	Ports                rtcconfig.PortRange
+	MediaTimeoutInitial  time.Duration
+	MediaTimeout         time.Duration
+	SymmetricRTP         bool
+	IgnoreLocalAddrInSDP bool // enable symmetric RTP if local IP is specified in SDP
+	Stats                *PortStats
+	EnableJitterBuffer   bool
+	NoInputResample      bool
+	IgnorePreanswerData  bool
+	LogSignalChanges     bool
 }
 
 func NewMediaPort(tid traceid.ID, log logger.Logger, mon *stats.CallMonitor, opts *MediaOptions, sampleRate int) (*MediaPort, error) {
@@ -676,7 +687,11 @@ func (p *MediaPort) SetConfig(c *MediaConf) error {
 		"srtp", crypto,
 	)
 
+	symmetric := p.opts.IgnoreLocalAddrInSDP && c.Remote.Addr().IsPrivate()
 	p.port.SetDst(c.Remote)
+	if symmetric {
+		p.port.SetSymmetric(true)
+	}
 	if p.opts.IgnorePreanswerData {
 		// this needs to happen before the SRTP session is created, otherwise the read deadline will be
 		// overwritten and we may get stuck in the discard loop
@@ -697,7 +712,9 @@ func (p *MediaPort) SetConfig(c *MediaConf) error {
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.port.SetDst(c.Remote)
+	if !symmetric {
+		p.port.SetDst(c.Remote)
+	}
 	p.conf = c
 	p.sess = sess
 

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -356,6 +356,10 @@ func checkPCM(t testing.TB, exp, got msdk.PCM16Sample) {
 }
 
 func newMediaPair(t testing.TB, opt1, opt2 *MediaOptions) (m1, m2 *MediaPort) {
+	return newMediaPairWithAddr(t, newIP("1.1.1.1"), newIP("2.2.2.2"), opt1, opt2)
+}
+
+func newMediaPairWithAddr(t testing.TB, ip1, ip2 netip.Addr, opt1, opt2 *MediaOptions) (m1, m2 *MediaPort) {
 	if opt1 == nil {
 		opt1 = &MediaOptions{}
 	}
@@ -366,11 +370,11 @@ func newMediaPair(t testing.TB, opt1, opt2 *MediaOptions) (m1, m2 *MediaPort) {
 
 	codecs := defaultCodecs
 
-	opt1.IP = newIP("1.1.1.1")
+	opt1.IP = ip1
 	opt1.Ports = rtcconfig.PortRange{Start: 10000}
 	opt1.NoInputResample = true
 
-	opt2.IP = newIP("2.2.2.2")
+	opt2.IP = ip2
 	opt2.Ports = rtcconfig.PortRange{Start: 20000}
 
 	const rate = 16000
@@ -605,5 +609,34 @@ func TestSymmetricRTP(t *testing.T) {
 		curDstPtr := m1.port.dst.Load()
 		require.NotNil(t, curDstPtr)
 		require.Equal(t, newAddr, *curDstPtr)
+	})
+
+	t.Run("auto", func(t *testing.T) {
+		m1, m2 := newMediaPairWithAddr(t,
+			newIP("1.1.1.1"), newIP("10.10.10.10"),
+			&MediaOptions{IgnoreLocalAddrInSDP: true}, nil,
+		)
+		dstPtr := m1.port.dst.Load()
+		require.NotNil(t, dstPtr)
+		require.True(t, dstPtr.IsValid())
+		symmetric := m1.port.symmetric.Load()
+		require.True(t, symmetric)
+
+		c2 := m2.port.UDPConn.(*testUDPConn)
+		newAddr := netip.AddrPortFrom(newIP("3.3.3.3"), 9999)
+		c2.addr = newAddr
+
+		err := m2.GetAudioWriter().WriteSample(msdk.PCM16Sample{0, 0})
+		require.NoError(t, err)
+
+		select {
+		case <-m1.Received():
+		case <-time.After(time.Second):
+			t.Fatal("no media received")
+		}
+
+		curDstPtr := m1.port.dst.Load()
+		require.NotNil(t, curDstPtr)
+		require.Equal(t, newAddr.String(), curDstPtr.String())
 	})
 }

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -137,16 +137,17 @@ func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Confi
 	var err error
 
 	call.media, err = NewMediaPort(tid, call.log, call.mon, &MediaOptions{
-		IP:                  c.sconf.MediaIP,
-		Ports:               conf.RTPPort,
-		MediaTimeoutInitial: c.conf.MediaTimeoutInitial,
-		MediaTimeout:        sipConf.mediaConfig.MediaTimeout,
-		SymmetricRTP:        c.conf.SymmetricRTP,
-		EnableJitterBuffer:  call.jitterBuf,
-		LogSignalChanges:    signalLoggingEnabled,
-		Stats:               &call.stats.Port,
-		NoInputResample:     !RoomResample,
-		IgnorePreanswerData: true,
+		IP:                   c.sconf.MediaIP,
+		Ports:                conf.RTPPort,
+		MediaTimeoutInitial:  c.conf.MediaTimeoutInitial,
+		MediaTimeout:         sipConf.mediaConfig.MediaTimeout,
+		SymmetricRTP:         c.conf.SymmetricRTP,
+		IgnoreLocalAddrInSDP: c.conf.IgnoreLocalAddrInSDP,
+		EnableJitterBuffer:   call.jitterBuf,
+		LogSignalChanges:     signalLoggingEnabled,
+		Stats:                &call.stats.Port,
+		NoInputResample:      !RoomResample,
+		IgnorePreanswerData:  true,
 	}, RoomSampleRate)
 	if err != nil {
 		call.close(ctx, errors.Wrap(err, "media failed"), callDropped, stats.ServerError("media-failed"), livekit.DisconnectReason_UNKNOWN_REASON)


### PR DESCRIPTION
Automatically enable symmetric RTP if the other peer send a local IP in their SDP. Fixes #611