### PR TITLE
TEL-588: better categorization of invite-failed for outbound calls

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -142,5 +142,5 @@ require (
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260427160629-7cedc36a6bc4 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260427160629-7cedc36a6bc4 // indirect
-	google.golang.org/grpc v1.80.0 // indirect
+	google.golang.org/grpc v1.80.0
 )

--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"net"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"github.com/livekit/media-sdk/sdp"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/psrpc"
@@ -42,12 +45,18 @@ var _ inviteClassifier = SDPError{}
 func (e SDPError) Error() string { return e.Err.Error() }
 func (e SDPError) Unwrap() error { return e.Err }
 
+// GRPCStatus lets psrpc.GetErrorCode (and any gRPC-aware caller) extract the
+// failed-precondition code without manual psrpc.NewError wrapping.
+func (e SDPError) GRPCStatus() *status.Status {
+	return status.New(codes.FailedPrecondition, e.Err.Error())
+}
+
 func (e SDPError) ClassifyInvite() inviteFailure {
 	res := inviteFailure{
 		status:    callRejected,
 		reason:    livekit.DisconnectReason_MEDIA_FAILURE,
 		reportErr: e.Err,
-		returnErr: psrpc.NewError(psrpc.FailedPrecondition, e.Err),
+		returnErr: e,
 	}
 	switch {
 	case errors.Is(e.Err, sdp.ErrNoCommonMedia):

--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -2,10 +2,9 @@ package sip
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
-
-	"github.com/pkg/errors"
 
 	"github.com/livekit/media-sdk/sdp"
 	"github.com/livekit/protocol/livekit"
@@ -69,8 +68,7 @@ func classifyInviteError(err error) inviteErrorClassification {
 		returnErr: err,
 	}
 
-	var sipStatus *livekit.SIPStatus
-	if errors.As(err, &sipStatus) {
+	if sipStatus, ok := errors.AsType[*livekit.SIPStatus](err); ok {
 		code := int(sipStatus.Code)
 		switch code {
 		case int(sip.StatusUnauthorized), int(sip.StatusProxyAuthRequired):
@@ -110,8 +108,7 @@ func classifyInviteError(err error) inviteErrorClassification {
 		return res
 	}
 
-	var sdpErr SDPError
-	if errors.As(err, &sdpErr) {
+	if sdpErr, ok := errors.AsType[SDPError](err); ok {
 		res.status, res.reason = callRejected, livekit.DisconnectReason_MEDIA_FAILURE
 		res.reportErr = nil
 		res.returnErr = psrpc.NewError(psrpc.FailedPrecondition, sdpErr.Err)
@@ -148,20 +145,17 @@ func classifyInviteError(err error) inviteErrorClassification {
 	}
 
 	// Specific net error types before *net.OpError (which wraps them).
-	var addrErr *net.AddrError
-	if errors.As(err, &addrErr) {
+	if _, ok := errors.AsType[*net.AddrError](err); ok {
 		res.status, res.term, res.reason = callDropped, stats.ClientError("address-error"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
 		res.returnErr = psrpc.NewError(psrpc.InvalidArgument, err)
 		return res
 	}
-	var dnsErr *net.DNSError
-	if errors.As(err, &dnsErr) {
+	if _, ok := errors.AsType[*net.DNSError](err); ok {
 		res.status, res.term, res.reason = callDropped, stats.ClientError("dns-resolution"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
 		res.returnErr = psrpc.NewError(psrpc.InvalidArgument, err)
 		return res
 	}
-	var opErr *net.OpError
-	if errors.As(err, &opErr) {
+	if _, ok := errors.AsType[*net.OpError](err); ok {
 		res.status, res.term, res.reason = callDropped, stats.ServerError("network-error"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
 		res.returnErr = psrpc.NewError(psrpc.Unavailable, err)
 		return res

--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -37,6 +37,8 @@ type SDPError struct {
 	Err error
 }
 
+var _ inviteClassifier = SDPError{}
+
 func (e SDPError) Error() string { return e.Err.Error() }
 func (e SDPError) Unwrap() error { return e.Err }
 
@@ -44,7 +46,7 @@ func (e SDPError) ClassifyInvite() inviteFailure {
 	res := inviteFailure{
 		status:    callRejected,
 		reason:    livekit.DisconnectReason_MEDIA_FAILURE,
-		reportErr: nil,
+		reportErr: e.Err,
 		returnErr: psrpc.NewError(psrpc.FailedPrecondition, e.Err),
 	}
 	switch {

--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -1,6 +1,7 @@
 package sip
 
 import (
+	"context"
 	"fmt"
 	"net"
 
@@ -47,8 +48,16 @@ type inviteErrorClassification struct {
 //   - SDP negotiation failures → client_error subclasses.
 //   - Ringing-timeout / context cancel (ErrSIPRequestTimeout) → client_error
 //     "no-answer" since the callee never picked up.
-//   - DNS resolution failures → client_error "dns-resolution" (caller's
-//     trunk URI is wrong).
+//   - context.DeadlineExceeded → server_error "deadline-exceeded".
+//   - context.Canceled → client_error "canceled" (caller pulled the plug).
+//   - DNS resolution failures → client_error "dns-resolution" (trunk URI is
+//     wrong, wrapped as psrpc.InvalidArgument).
+//   - Address parsing failures (*net.AddrError) → client_error "address-error"
+//     (trunk address is malformed, wrapped as psrpc.InvalidArgument).
+//   - Generic network op errors (*net.OpError) → server_error "network-error"
+//     (trunk unreachable; ambiguous whether the cause is the customer's trunk
+//     or our outbound network — conservatively kept in server_error so SLI
+//     stays visible, wrapped as psrpc.Unavailable).
 //   - Auth failures (missing creds, max-retry, missing header) → client_error
 //     "auth-failed" (caller's trunk auth config is wrong).
 func classifyInviteError(err error) inviteErrorClassification {
@@ -123,14 +132,38 @@ func classifyInviteError(err error) inviteErrorClassification {
 		return res
 	}
 
+	// Context cancellation / deadline. Check before *net.OpError because an
+	// op error can wrap a context error, and the context cause is more
+	// informative.
+	if errors.Is(err, context.DeadlineExceeded) {
+		res.status, res.term, res.reason = callDropped, stats.ServerError("deadline-exceeded"), livekit.DisconnectReason_UNKNOWN_REASON
+		res.returnErr = psrpc.NewError(psrpc.DeadlineExceeded, err)
+		return res
+	}
+	if errors.Is(err, context.Canceled) {
+		res.status, res.term, res.reason = callRejected, stats.ClientError("canceled"), livekit.DisconnectReason_USER_UNAVAILABLE
+		res.reportErr = nil
+		res.returnErr = psrpc.NewError(psrpc.Canceled, err)
+		return res
+	}
+
+	// Specific net error types before *net.OpError (which wraps them).
+	var addrErr *net.AddrError
+	if errors.As(err, &addrErr) {
+		res.status, res.term, res.reason = callDropped, stats.ClientError("address-error"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
+		res.returnErr = psrpc.NewError(psrpc.InvalidArgument, err)
+		return res
+	}
 	var dnsErr *net.DNSError
 	if errors.As(err, &dnsErr) {
 		res.status, res.term, res.reason = callDropped, stats.ClientError("dns-resolution"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
-		// keep reportErr so the DNS detail is recorded in SIPCallInfo;
-		// wrap returnErr so callers across the RPC boundary see a 400
-		// (InvalidArgument — the trunk URI is bad) instead of an
-		// auto-wrapped Internal/500.
 		res.returnErr = psrpc.NewError(psrpc.InvalidArgument, err)
+		return res
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		res.status, res.term, res.reason = callDropped, stats.ServerError("network-error"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
+		res.returnErr = psrpc.NewError(psrpc.Unavailable, err)
 		return res
 	}
 

--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -14,53 +14,60 @@ import (
 	"github.com/livekit/sip/pkg/stats"
 )
 
+// inviteFailure is the verdict for a failed outbound INVITE: how to record
+// the call, how to bucket the SLI, and which error to surface back.
+type inviteFailure struct {
+	status    CallStatus
+	term      stats.Termination
+	reason    livekit.DisconnectReason
+	reportErr error // nil skips writing SIPCallInfo.Error
+	returnErr error
+}
+
+// inviteClassifier lets an error describe its own verdict instead of
+// classifyInviteError carrying a switch over every variant. Source sites
+// wrap raw errors in these types so the classification lives next to where
+// the failure happened.
+type inviteClassifier interface {
+	error
+	ClassifyInvite() inviteFailure
+}
+
 type SDPError struct {
 	Err error
 }
 
-func (e SDPError) Error() string {
-	return e.Err.Error()
+func (e SDPError) Error() string { return e.Err.Error() }
+func (e SDPError) Unwrap() error { return e.Err }
+
+func (e SDPError) ClassifyInvite() inviteFailure {
+	res := inviteFailure{
+		status:    callRejected,
+		reason:    livekit.DisconnectReason_MEDIA_FAILURE,
+		reportErr: nil,
+		returnErr: psrpc.NewError(psrpc.FailedPrecondition, e.Err),
+	}
+	switch {
+	case errors.Is(e.Err, sdp.ErrNoCommonMedia):
+		res.term = stats.ClientError("no-common-codec")
+	case errors.Is(e.Err, sdp.ErrNoCommonCrypto):
+		res.term = stats.ClientError("encryption-required")
+	default:
+		res.term = stats.ClientError("sdp-error")
+	}
+	return res
 }
 
-func (e SDPError) Unwrap() error {
-	return e.Err
-}
+// classifyInviteError buckets an outbound INVITE error. Self-classifying
+// errors describe themselves; the residual switch covers external types we
+// can't extend (SIPStatus, net.*, context.*) and falls back to
+// ServerError("invite-failed") so unknown modes still flag the SLI.
+func classifyInviteError(err error) inviteFailure {
+	if ic, ok := errors.AsType[inviteClassifier](err); ok {
+		return ic.ClassifyInvite()
+	}
 
-// inviteErrorClassification captures everything connectSIP needs after a
-// dialSIP failure: how to record the call, how to bucket the SLI, and which
-// error (if any) to surface back to the caller and the call record.
-type inviteErrorClassification struct {
-	status    CallStatus
-	term      stats.Termination
-	reason    livekit.DisconnectReason
-	reportErr error // passed to c.close; nil means don't write to SIPCallInfo.Error
-	returnErr error // returned from connectSIP; defaults to the original err
-}
-
-// classifyInviteError buckets an outbound dialSIP error. The default is the
-// conservative ServerError("invite-failed") so that genuinely unknown failure
-// modes still get flagged. Known buckets:
-//
-//   - SIP status response from the customer's SIP trunk: 4xx → client_error,
-//     5xx → server_error with a distinct upstream label, 6xx → client_error.
-//     A handful of common codes get more specific reason labels.
-//   - SDP negotiation failures → client_error subclasses.
-//   - Ringing-timeout / context cancel (ErrSIPRequestTimeout) → client_error
-//     "no-answer" since the callee never picked up.
-//   - context.DeadlineExceeded → server_error "deadline-exceeded".
-//   - context.Canceled → client_error "canceled" (caller pulled the plug).
-//   - DNS resolution failures → client_error "dns-resolution" (trunk URI is
-//     wrong, wrapped as psrpc.InvalidArgument).
-//   - Address parsing failures (*net.AddrError) → client_error "address-error"
-//     (trunk address is malformed, wrapped as psrpc.InvalidArgument).
-//   - Generic network op errors (*net.OpError) → server_error "network-error"
-//     (trunk unreachable; ambiguous whether the cause is the customer's trunk
-//     or our outbound network — conservatively kept in server_error so SLI
-//     stays visible, wrapped as psrpc.Unavailable).
-//   - Auth failures (missing creds, max-retry, missing header) → client_error
-//     "auth-failed" (caller's trunk auth config is wrong).
-func classifyInviteError(err error) inviteErrorClassification {
-	res := inviteErrorClassification{
+	res := inviteFailure{
 		status:    callDropped,
 		term:      stats.ServerError("invite-failed"),
 		reason:    livekit.DisconnectReason_UNKNOWN_REASON,
@@ -104,21 +111,6 @@ func classifyInviteError(err error) inviteErrorClassification {
 				res.status, res.term, res.reason = callRejected, stats.ClientError(fmt.Sprintf("global-decline-%d", code)), livekit.DisconnectReason_USER_REJECTED
 				res.reportErr = nil
 			}
-		}
-		return res
-	}
-
-	if sdpErr, ok := errors.AsType[SDPError](err); ok {
-		res.status, res.reason = callRejected, livekit.DisconnectReason_MEDIA_FAILURE
-		res.reportErr = nil
-		res.returnErr = psrpc.NewError(psrpc.FailedPrecondition, sdpErr.Err)
-		switch {
-		case errors.Is(sdpErr.Err, sdp.ErrNoCommonMedia):
-			res.term = stats.ClientError("no-common-codec")
-		case errors.Is(sdpErr.Err, sdp.ErrNoCommonCrypto):
-			res.term = stats.ClientError("encryption-required")
-		default:
-			res.term = stats.ClientError("sdp-error")
 		}
 		return res
 	}

--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -1,5 +1,19 @@
 package sip
 
+import (
+	"fmt"
+	"net"
+
+	"github.com/pkg/errors"
+
+	"github.com/livekit/media-sdk/sdp"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/psrpc"
+	"github.com/livekit/sipgo/sip"
+
+	"github.com/livekit/sip/pkg/stats"
+)
+
 type SDPError struct {
 	Err error
 }
@@ -10,4 +24,121 @@ func (e SDPError) Error() string {
 
 func (e SDPError) Unwrap() error {
 	return e.Err
+}
+
+// inviteErrorClassification captures everything connectSIP needs after a
+// dialSIP failure: how to record the call, how to bucket the SLI, and which
+// error (if any) to surface back to the caller and the call record.
+type inviteErrorClassification struct {
+	status    CallStatus
+	term      stats.Termination
+	reason    livekit.DisconnectReason
+	reportErr error // passed to c.close; nil means don't write to SIPCallInfo.Error
+	returnErr error // returned from connectSIP; defaults to the original err
+}
+
+// classifyInviteError buckets an outbound dialSIP error. The default is the
+// conservative ServerError("invite-failed") so that genuinely unknown failure
+// modes still get flagged. Known buckets:
+//
+//   - SIP status response from the customer's SIP trunk: 4xx → client_error,
+//     5xx → server_error with a distinct upstream label, 6xx → client_error.
+//     A handful of common codes get more specific reason labels.
+//   - SDP negotiation failures → client_error subclasses.
+//   - Ringing-timeout / context cancel (ErrSIPRequestTimeout) → client_error
+//     "no-answer" since the callee never picked up.
+//   - DNS resolution failures → client_error "dns-resolution" (caller's
+//     trunk URI is wrong).
+//   - Auth failures (missing creds, max-retry, missing header) → client_error
+//     "auth-failed" (caller's trunk auth config is wrong).
+func classifyInviteError(err error) inviteErrorClassification {
+	res := inviteErrorClassification{
+		status:    callDropped,
+		term:      stats.ServerError("invite-failed"),
+		reason:    livekit.DisconnectReason_UNKNOWN_REASON,
+		reportErr: err,
+		returnErr: err,
+	}
+
+	var sipStatus *livekit.SIPStatus
+	if errors.As(err, &sipStatus) {
+		code := int(sipStatus.Code)
+		switch code {
+		case int(sip.StatusUnauthorized), int(sip.StatusProxyAuthRequired):
+			res.status, res.term, res.reason = callRejected, stats.ClientError("auth-required"), livekit.DisconnectReason_USER_REJECTED
+			res.reportErr = nil
+		case int(sip.StatusForbidden):
+			res.status, res.term, res.reason = callRejected, stats.ClientError("forbidden"), livekit.DisconnectReason_USER_REJECTED
+			res.reportErr = nil
+		case int(sip.StatusNotFound):
+			res.status, res.term, res.reason = callUnavailable, stats.ClientError("not-found"), livekit.DisconnectReason_USER_UNAVAILABLE
+			res.reportErr = nil
+		case int(sip.StatusRequestTimeout):
+			res.status, res.term, res.reason = callUnavailable, stats.ClientError("request-timeout"), livekit.DisconnectReason_USER_UNAVAILABLE
+			res.reportErr = nil
+		case int(sip.StatusTemporarilyUnavailable):
+			res.status, res.term, res.reason = callUnavailable, stats.ClientError("unavailable"), livekit.DisconnectReason_USER_UNAVAILABLE
+			res.reportErr = nil
+		case int(sip.StatusBusyHere):
+			res.status, res.term, res.reason = callRejected, stats.ClientError("busy"), livekit.DisconnectReason_USER_REJECTED
+			res.reportErr = nil
+		case int(sip.StatusNotAcceptableHere):
+			res.status, res.term, res.reason = callRejected, stats.ClientError("not-acceptable"), livekit.DisconnectReason_USER_REJECTED
+			res.reportErr = nil
+		default:
+			switch {
+			case code >= 400 && code < 500:
+				res.status, res.term, res.reason = callRejected, stats.ClientError(fmt.Sprintf("client-error-%d", code)), livekit.DisconnectReason_USER_UNAVAILABLE
+				res.reportErr = nil
+			case code >= 500 && code < 600:
+				res.status, res.term, res.reason = callDropped, stats.ServerError(fmt.Sprintf("upstream-server-error-%d", code)), livekit.DisconnectReason_SIP_TRUNK_FAILURE
+				// keep reportErr so 5xx detail is recorded
+			case code >= 600 && code < 700:
+				res.status, res.term, res.reason = callRejected, stats.ClientError(fmt.Sprintf("global-decline-%d", code)), livekit.DisconnectReason_USER_REJECTED
+				res.reportErr = nil
+			}
+		}
+		return res
+	}
+
+	var sdpErr SDPError
+	if errors.As(err, &sdpErr) {
+		res.status, res.reason = callRejected, livekit.DisconnectReason_MEDIA_FAILURE
+		res.reportErr = nil
+		res.returnErr = psrpc.NewError(psrpc.FailedPrecondition, sdpErr.Err)
+		switch {
+		case errors.Is(sdpErr.Err, sdp.ErrNoCommonMedia):
+			res.term = stats.ClientError("no-common-codec")
+		case errors.Is(sdpErr.Err, sdp.ErrNoCommonCrypto):
+			res.term = stats.ClientError("encryption-required")
+		default:
+			res.term = stats.ClientError("sdp-error")
+		}
+		return res
+	}
+
+	if errors.Is(err, ErrSIPRequestTimeout) {
+		res.status, res.term, res.reason = callUnavailable, stats.ClientError("no-answer"), livekit.DisconnectReason_USER_UNAVAILABLE
+		res.reportErr = nil
+		return res
+	}
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		res.status, res.term, res.reason = callDropped, stats.ClientError("dns-resolution"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
+		// keep reportErr so the DNS detail is recorded in SIPCallInfo;
+		// wrap returnErr so callers across the RPC boundary see a 400
+		// (InvalidArgument — the trunk URI is bad) instead of an
+		// auto-wrapped Internal/500.
+		res.returnErr = psrpc.NewError(psrpc.InvalidArgument, err)
+		return res
+	}
+
+	if errors.Is(err, ErrAuthMaxRetry) || errors.Is(err, ErrAuthMissingCreds) || errors.Is(err, ErrAuthNoHeader) {
+		res.status, res.term, res.reason = callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED
+		// keep reportErr so the auth detail is recorded
+		return res
+	}
+
+	return res
 }

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -55,9 +55,9 @@ func TestClassifyInviteError(t *testing.T) {
 		{"603 Global Decline", sipStatusErr(603), callRejected, stats.ClientError("global-decline-603"), livekit.DisconnectReason_USER_REJECTED, false},
 
 		// SDP errors
-		{"SDP no common media", SDPError{Err: sdp.ErrNoCommonMedia}, callRejected, stats.ClientError("no-common-codec"), livekit.DisconnectReason_MEDIA_FAILURE, false},
-		{"SDP no common crypto", SDPError{Err: sdp.ErrNoCommonCrypto}, callRejected, stats.ClientError("encryption-required"), livekit.DisconnectReason_MEDIA_FAILURE, false},
-		{"SDP other", SDPError{Err: errors.New("bad sdp")}, callRejected, stats.ClientError("sdp-error"), livekit.DisconnectReason_MEDIA_FAILURE, false},
+		{"SDP no common media", SDPError{Err: sdp.ErrNoCommonMedia}, callRejected, stats.ClientError("no-common-codec"), livekit.DisconnectReason_MEDIA_FAILURE, true},
+		{"SDP no common crypto", SDPError{Err: sdp.ErrNoCommonCrypto}, callRejected, stats.ClientError("encryption-required"), livekit.DisconnectReason_MEDIA_FAILURE, true},
+		{"SDP other", SDPError{Err: errors.New("bad sdp")}, callRejected, stats.ClientError("sdp-error"), livekit.DisconnectReason_MEDIA_FAILURE, true},
 
 		// Sentinel-based errors
 		{"SIP request timeout (no answer)", psrpc.NewError(psrpc.Canceled, ErrSIPRequestTimeout), callUnavailable, stats.ClientError("no-answer"), livekit.DisconnectReason_USER_UNAVAILABLE, false},

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -1,6 +1,7 @@
 package sip
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -64,8 +65,14 @@ func TestClassifyInviteError(t *testing.T) {
 		{"Auth missing creds", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthMissingCreds), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},
 		{"Auth no header", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthNoHeader), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},
 
-		// DNS error
+		// Context cancellation / deadline
+		{"context.DeadlineExceeded", context.DeadlineExceeded, callDropped, stats.ServerError("deadline-exceeded"), livekit.DisconnectReason_UNKNOWN_REASON, true},
+		{"context.Canceled", context.Canceled, callRejected, stats.ClientError("canceled"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+
+		// Net errors
 		{"DNS no such host", &net.DNSError{Err: "no such host", Name: "voip.example.com", IsNotFound: true}, callDropped, stats.ClientError("dns-resolution"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"AddrError missing port", &net.AddrError{Err: "missing port", Addr: "voip.example.com"}, callDropped, stats.ClientError("address-error"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"OpError dial refused", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, callDropped, stats.ServerError("network-error"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 
 		// Unknown — conservative default
 		{"Unknown error", errors.New("something broke"), callDropped, stats.ServerError("invite-failed"), livekit.DisconnectReason_UNKNOWN_REASON, true},
@@ -95,3 +102,27 @@ func TestClassifyInviteError_SDPReplacesReturnErr(t *testing.T) {
 	require.True(t, errors.Is(res.returnErr, sdp.ErrNoCommonMedia))
 }
 
+func TestClassifyInviteError_ReturnErrWrap(t *testing.T) {
+	// Refined buckets that wrap returnErr with a specific psrpc code so the
+	// RPC boundary reflects the originating failure mode instead of an
+	// auto-wrapped Internal/500.
+	cases := []struct {
+		name     string
+		err      error
+		wantCode psrpc.ErrorCode
+	}{
+		{"context.DeadlineExceeded", context.DeadlineExceeded, psrpc.DeadlineExceeded},
+		{"context.Canceled", context.Canceled, psrpc.Canceled},
+		{"*net.DNSError", &net.DNSError{Err: "no such host", Name: "voip.example.com", IsNotFound: true}, psrpc.InvalidArgument},
+		{"*net.AddrError", &net.AddrError{Err: "missing port", Addr: "voip.example.com"}, psrpc.InvalidArgument},
+		{"*net.OpError", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, psrpc.Unavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := classifyInviteError(tc.err)
+			var psErr psrpc.Error
+			require.True(t, errors.As(res.returnErr, &psErr), "returnErr should be a psrpc.Error")
+			require.Equal(t, tc.wantCode, psErr.Code())
+		})
+	}
+}

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -93,13 +93,13 @@ func TestClassifyInviteError(t *testing.T) {
 	}
 }
 
-func TestClassifyInviteError_SDPReplacesReturnErr(t *testing.T) {
-	// SDP path rewraps the error as psrpc FailedPrecondition; confirm
-	// returnErr differs from the input.
+func TestClassifyInviteError_SDPGRPCStatus(t *testing.T) {
 	in := SDPError{Err: sdp.ErrNoCommonMedia}
 	res := classifyInviteError(in)
-	require.NotEqual(t, error(in), res.returnErr)
 	require.True(t, errors.Is(res.returnErr, sdp.ErrNoCommonMedia))
+	code, ok := psrpc.GetErrorCode(res.returnErr)
+	require.True(t, ok)
+	require.Equal(t, psrpc.FailedPrecondition, code)
 }
 
 func TestClassifyInviteError_ReturnErrWrap(t *testing.T) {

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -1,0 +1,97 @@
+package sip
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/livekit/media-sdk/sdp"
+	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/psrpc"
+
+	"github.com/livekit/sip/pkg/stats"
+)
+
+func TestClassifyInviteError(t *testing.T) {
+	sipStatusErr := func(code int) error {
+		return fmt.Errorf("INVITE failed: %w", &livekit.SIPStatus{
+			Code:   livekit.SIPStatusCode(code),
+			Status: "test",
+		})
+	}
+
+	cases := []struct {
+		name       string
+		err        error
+		wantStatus CallStatus
+		wantTerm   stats.Termination
+		wantReason livekit.DisconnectReason
+		wantReport bool // true if reportErr should be non-nil
+	}{
+		// Specific SIP status codes
+		{"401 Unauthorized", sipStatusErr(401), callRejected, stats.ClientError("auth-required"), livekit.DisconnectReason_USER_REJECTED, false},
+		{"403 Forbidden", sipStatusErr(403), callRejected, stats.ClientError("forbidden"), livekit.DisconnectReason_USER_REJECTED, false},
+		{"404 Not Found", sipStatusErr(404), callUnavailable, stats.ClientError("not-found"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+		{"407 Proxy Auth Required", sipStatusErr(407), callRejected, stats.ClientError("auth-required"), livekit.DisconnectReason_USER_REJECTED, false},
+		{"408 Request Timeout", sipStatusErr(408), callUnavailable, stats.ClientError("request-timeout"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+		{"480 Temporarily Unavailable", sipStatusErr(480), callUnavailable, stats.ClientError("unavailable"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+		{"486 Busy Here", sipStatusErr(486), callRejected, stats.ClientError("busy"), livekit.DisconnectReason_USER_REJECTED, false},
+		{"488 Not Acceptable Here", sipStatusErr(488), callRejected, stats.ClientError("not-acceptable"), livekit.DisconnectReason_USER_REJECTED, false},
+
+		// 4xx catch-all
+		{"410 Gone (4xx catch-all)", sipStatusErr(410), callRejected, stats.ClientError("client-error-410"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+		{"487 Request Terminated (4xx catch-all)", sipStatusErr(487), callRejected, stats.ClientError("client-error-487"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+
+		// 5xx upstream server error
+		{"500 Internal Server Error", sipStatusErr(500), callDropped, stats.ServerError("upstream-server-error-500"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"503 Service Unavailable", sipStatusErr(503), callDropped, stats.ServerError("upstream-server-error-503"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+
+		// 6xx global decline
+		{"600 Global Busy Everywhere", sipStatusErr(600), callRejected, stats.ClientError("global-decline-600"), livekit.DisconnectReason_USER_REJECTED, false},
+		{"603 Global Decline", sipStatusErr(603), callRejected, stats.ClientError("global-decline-603"), livekit.DisconnectReason_USER_REJECTED, false},
+
+		// SDP errors
+		{"SDP no common media", SDPError{Err: sdp.ErrNoCommonMedia}, callRejected, stats.ClientError("no-common-codec"), livekit.DisconnectReason_MEDIA_FAILURE, false},
+		{"SDP no common crypto", SDPError{Err: sdp.ErrNoCommonCrypto}, callRejected, stats.ClientError("encryption-required"), livekit.DisconnectReason_MEDIA_FAILURE, false},
+		{"SDP other", SDPError{Err: errors.New("bad sdp")}, callRejected, stats.ClientError("sdp-error"), livekit.DisconnectReason_MEDIA_FAILURE, false},
+
+		// Sentinel-based errors
+		{"SIP request timeout (no answer)", psrpc.NewError(psrpc.Canceled, ErrSIPRequestTimeout), callUnavailable, stats.ClientError("no-answer"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+		{"Auth max retry", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthMaxRetry), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},
+		{"Auth missing creds", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthMissingCreds), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},
+		{"Auth no header", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthNoHeader), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},
+
+		// DNS error
+		{"DNS no such host", &net.DNSError{Err: "no such host", Name: "voip.example.com", IsNotFound: true}, callDropped, stats.ClientError("dns-resolution"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+
+		// Unknown — conservative default
+		{"Unknown error", errors.New("something broke"), callDropped, stats.ServerError("invite-failed"), livekit.DisconnectReason_UNKNOWN_REASON, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := classifyInviteError(tc.err)
+			require.Equal(t, tc.wantStatus, res.status, "status")
+			require.Equal(t, tc.wantTerm, res.term, "termination")
+			require.Equal(t, tc.wantReason, res.reason, "disconnect reason")
+			if tc.wantReport {
+				require.NotNil(t, res.reportErr, "reportErr expected non-nil")
+			} else {
+				require.Nil(t, res.reportErr, "reportErr expected nil")
+			}
+		})
+	}
+}
+
+func TestClassifyInviteError_SDPReplacesReturnErr(t *testing.T) {
+	// SDP path rewraps the error as psrpc FailedPrecondition; confirm
+	// returnErr differs from the input.
+	in := SDPError{Err: sdp.ErrNoCommonMedia}
+	res := classifyInviteError(in)
+	require.NotEqual(t, error(in), res.returnErr)
+	require.True(t, errors.Is(res.returnErr, sdp.ErrNoCommonMedia))
+}
+

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -31,7 +31,6 @@ import (
 
 	msdk "github.com/livekit/media-sdk"
 	"github.com/livekit/media-sdk/dtmf"
-	"github.com/livekit/media-sdk/sdp"
 	"github.com/livekit/media-sdk/tones"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -390,52 +389,9 @@ func (c *outboundCall) connectSIP(ctx context.Context, tid traceid.ID) error {
 	defer c.mu.Unlock()
 	if err := c.dialSIP(ctx, tid); err != nil {
 		c.log.Infow("SIP call failed", "error", err)
-
-		reportErr := err
-		status, term, reason := callDropped, stats.ServerError("invite-failed"), livekit.DisconnectReason_UNKNOWN_REASON
-		var e *livekit.SIPStatus
-		if errors.As(err, &e) {
-			switch int(e.Code) {
-			case int(sip.StatusTemporarilyUnavailable):
-				status, term, reason = callUnavailable, stats.ClientError("unavailable"), livekit.DisconnectReason_USER_UNAVAILABLE
-				reportErr = nil
-			case int(sip.StatusBusyHere):
-				status, term, reason = callRejected, stats.ClientError("busy"), livekit.DisconnectReason_USER_REJECTED
-				reportErr = nil
-			}
-		} else if e := (SDPError{}); errors.As(err, &e) {
-			status, reason = callRejected, livekit.DisconnectReason_MEDIA_FAILURE
-			reportErr = nil
-			err = psrpc.NewError(psrpc.FailedPrecondition, e.Err)
-			if errors.Is(e.Err, sdp.ErrNoCommonMedia) {
-				term = stats.ClientError("no-common-codec")
-			} else if errors.Is(e.Err, sdp.ErrNoCommonCrypto) {
-				term = stats.ClientError("encryption-required")
-			} else {
-				term = stats.ClientError("sdp-error")
-			}
-		} else {
-			var psErr psrpc.Error
-			if !errors.As(err, &psErr) {
-				var (
-					opErr   *net.OpError
-					dnsErr  *net.DNSError
-					addrErr *net.AddrError
-				)
-				switch {
-				case errors.Is(err, context.DeadlineExceeded):
-					err = psrpc.NewError(psrpc.DeadlineExceeded, err)
-				case errors.Is(err, context.Canceled):
-					err = psrpc.NewError(psrpc.Canceled, err)
-				case errors.As(err, &addrErr):
-					err = psrpc.NewError(psrpc.InvalidArgument, err)
-				case errors.As(err, &dnsErr), errors.As(err, &opErr): // opErr needs to be checked last because it wraps addrErr and dnsErr
-					err = psrpc.NewError(psrpc.Unavailable, err)
-				}
-			}
-		}
-		c.close(ctx, reportErr, status, term, reason)
-		return err
+		res := classifyInviteError(err)
+		c.close(ctx, res.reportErr, res.status, res.term, res.reason)
+		return res.returnErr
 	}
 	c.connectMedia()
 	c.started.Break()
@@ -536,7 +492,7 @@ func sipResponse(ctx context.Context, tx sip.ClientTransaction, stop <-chan stru
 			_ = tx.Cancel()
 			// NOTE: psrpc.Canceled does not auto-retry, whereas psrpc.DeadlineExceeded does
 			// As long as that is the case, avoid psrpc.DeadlineExceeded to prevent hammering of destination.
-			return nil, psrpc.NewErrorf(psrpc.Canceled, "sip request timed out")
+			return nil, psrpc.NewError(psrpc.Canceled, ErrSIPRequestTimeout)
 		case <-stop:
 			_ = tx.Cancel()
 			return nil, psrpc.NewErrorf(psrpc.Canceled, "service shutting down")
@@ -949,7 +905,7 @@ func (c *sipOutbound) Invite(ctx context.Context, to URI, user, pass string, hea
 authLoop:
 	for try := 0; ; try++ {
 		if try >= 5 {
-			return nil, psrpc.NewError(psrpc.FailedPrecondition, fmt.Errorf("max auth retry attempts reached for SIP invite"))
+			return nil, psrpc.NewError(psrpc.FailedPrecondition, ErrAuthMaxRetry)
 		}
 		req, resp, err = c.attemptInvite(ctx, sip.CallIDHeader(c.callID), toHeader, sdpOffer, authHeaderRespName, authHeader, sipHeaders, setState)
 		if err != nil {
@@ -989,20 +945,20 @@ authLoop:
 		c.log.Infow("auth requested", "status", resp.StatusCode, "body", string(resp.Body()))
 		// auth required
 		if user == "" || pass == "" {
-			return nil, psrpc.NewError(psrpc.FailedPrecondition, errors.New("sip server required auth, but no username or password was provided"))
+			return nil, psrpc.NewError(psrpc.FailedPrecondition, ErrAuthMissingCreds)
 		}
 		headerVal := resp.GetHeader(authHeaderName)
 		if headerVal == nil {
-			return nil, psrpc.NewError(psrpc.FailedPrecondition, errors.New("no auth header in sip invite response"))
+			return nil, psrpc.NewError(psrpc.FailedPrecondition, ErrAuthNoHeader)
 		}
 		challengeStr := headerVal.Value()
 		challenge, err := digest.ParseChallenge(challengeStr)
 		if err != nil {
-			return nil, fmt.Errorf("invalid challenge %q: %w", challengeStr, err)
+			return nil, psrpc.NewErrorf(psrpc.Internal, "invalid challenge %q: %v", challengeStr, err)
 		}
 		toHeader := resp.To()
 		if toHeader == nil {
-			return nil, errors.New("no 'To' header on Response")
+			return nil, psrpc.NewErrorf(psrpc.Internal, "no 'To' header on Response")
 		}
 
 		cred, err := digest.Digest(challenge, digest.Options{
@@ -1021,12 +977,12 @@ authLoop:
 	c.invite, c.inviteOk = req, resp
 	toHeader = resp.To()
 	if toHeader == nil {
-		return nil, errors.New("no To header in INVITE response")
+		return nil, psrpc.NewErrorf(psrpc.Internal, "no To header in INVITE response")
 	}
 	var ok bool
 	c.tag, ok = getTagFrom(toHeader.Params)
 	if !ok {
-		return nil, errors.New("no tag in To header in INVITE response")
+		return nil, psrpc.NewErrorf(psrpc.Internal, "no tag in To header in INVITE response")
 	}
 
 	if cont := resp.Contact(); cont != nil {

--- a/pkg/sip/protocol.go
+++ b/pkg/sip/protocol.go
@@ -112,6 +112,15 @@ func statusName(status int) string {
 	return fmt.Sprintf("status-%d", status)
 }
 
+// Sentinel errors emitted on outbound dial failure paths so callers can match
+// them with errors.Is without depending on the human-readable message.
+var (
+	ErrSIPRequestTimeout = errors.New("sip request timed out")
+	ErrAuthMaxRetry      = errors.New("max auth retry attempts reached for SIP invite")
+	ErrAuthMissingCreds  = errors.New("sip server required auth, but no username or password was provided")
+	ErrAuthNoHeader      = errors.New("no auth header in sip invite response")
+)
+
 type setHeadersFunc func(headers map[string]string) map[string]string
 
 type Signaling interface {


### PR DESCRIPTION
A lot of invite-failed are client errors.