### PR TITLE
Support AMR-WB codec (optional).

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/icholy/digest v1.1.0
 	github.com/jfreymuth/oggvorbis v1.0.5
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
-	github.com/livekit/media-sdk v0.0.0-20260504125714-dd334c543809
+	github.com/livekit/media-sdk v0.0.0-20260522104028-d03750ae030c
 	github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8
 	github.com/livekit/protocol v1.45.9-0.20260518225207-2cfe2d2aa772
 	github.com/livekit/psrpc v0.7.1
@@ -52,6 +52,7 @@ require (
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dennwc/amrwb-cgo v0.0.0-20260520132032-df56718048c8 // indirect
 	github.com/dennwc/iters v1.2.2 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/distribution/reference v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dennwc/amrwb-cgo v0.0.0-20260520132032-df56718048c8 h1:UKqf4Oyvnn4xwiNXBFWJJXn6ZYktnD9lxHhYnt2lbW0=
+github.com/dennwc/amrwb-cgo v0.0.0-20260520132032-df56718048c8/go.mod h1:LjB85NWGb8sNoHWYbhbtkzLE1syqKTZT1Biks5BxNHo=
 github.com/dennwc/iters v1.2.2 h1:XH2/Etihiy9ZvPOVCR+icQXeYlhbvS7k0qro4x/2qQo=
 github.com/dennwc/iters v1.2.2/go.mod h1:M9KuuMBeyEXYTmB7EnI9SCyALFCmPWOIxn5W1L0CjGg=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
@@ -132,8 +134,8 @@ github.com/lithammer/shortuuid/v4 v4.2.0 h1:LMFOzVB3996a7b8aBuEXxqOBflbfPQAiVzkI
 github.com/lithammer/shortuuid/v4 v4.2.0/go.mod h1:D5noHZ2oFw/YaKCfGy0YxyE7M0wMbezmMjPdhyEFe6Y=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5ATTo469PQPkqzdoU7be46ryiCDO3boc=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/media-sdk v0.0.0-20260504125714-dd334c543809 h1:h0bfcFCXX3UjTnZ0bKR5c3XX+8jBEAQQ9LG30yfVnyc=
-github.com/livekit/media-sdk v0.0.0-20260504125714-dd334c543809/go.mod h1:7ssWiG+U4xnbvLih9WiZbhQP6zIKMjgXdUtIE1bm/E8=
+github.com/livekit/media-sdk v0.0.0-20260522104028-d03750ae030c h1:sMXJZn7FLcA51D7dHfvmz4HZNhgF+nyBXYkU4mIIWq0=
+github.com/livekit/media-sdk v0.0.0-20260522104028-d03750ae030c/go.mod h1:IEodVPCZ3eAscxH0GX4A+g6UbKMBon4yxeZOGgwCMrs=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8 h1:coWig9fKxdb/nwOaIoGUUAogso12GblAJh/9SA9hcxk=
 github.com/livekit/mediatransportutil v0.0.0-20260309115634-0e2e24b36ee8/go.mod h1:RCd46PT+6sEztld6XpkCrG1xskb0u3SqxIjy4G897Ss=
 github.com/livekit/protocol v1.45.9-0.20260518225207-2cfe2d2aa772 h1:JOlU9yyc65+qGW5os8fFgPtih89vSsGT+Dv42nzTMEw=

--- a/pkg/sip/media_codecs.go
+++ b/pkg/sip/media_codecs.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	_ "github.com/livekit/media-sdk/all"
+	"github.com/livekit/media-sdk/amrwb"
 	"github.com/livekit/media-sdk/dtmf"
 	"github.com/livekit/media-sdk/g711"
 	"github.com/livekit/media-sdk/g722"
@@ -37,6 +38,7 @@ func init() {
 		g711.ALawSDPName: true,
 		g711.ULawSDPName: true,
 		g722.SDPName:     true,
+		amrwb.SDPName:    false, // optional
 		dtmf.SDPName:     true,
 	})
 }
@@ -79,7 +81,25 @@ func codecSet(m *livekit.SIPMediaConfig) (*msdk.CodecSet, error) {
 		s = defaultCodecs.NewSet() // inherit from default
 	}
 	for _, codec := range m.Codecs {
-		name := fmt.Sprintf("%s/%d", codec.Name, codec.Rate)
+		name := codec.Name
+		if name == "" {
+			return nil, errors.New("no codec name specified")
+		}
+		rate := codec.Rate
+		if rate == 0 {
+			// Set default rate
+			switch name {
+			case g711.ALawSDPName, g711.ULawSDPName:
+				rate = 8000
+			case g722.SDPName:
+				rate = 8000 // actually 16000, it's a know bug in the spec
+			case amrwb.SDPName:
+				rate = 16000
+			default:
+				return nil, fmt.Errorf("sample rate not specified for codec: %q", name)
+			}
+		}
+		name = fmt.Sprintf("%s/%d", name, rate)
 		s.SetEnabled(name, true)
 	}
 	return s, nil

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -23,6 +23,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -165,19 +166,30 @@ func newIP(v string) netip.Addr {
 }
 
 func TestMediaPort(t *testing.T) {
+	// Main resampler has unpredictable (although tiny) output delay
+	// and other randomness in the generated samples.
+	// Enable a predictable resampler to avoid flaky tests.
+	prevOpts := msdk.DefaultResampleOptions
+	msdk.DefaultResampleOptions = []msdk.ResampleOption{
+		msdk.WithPredictableResample(true),
+	}
+	defer func() {
+		msdk.DefaultResampleOptions = prevOpts
+	}()
 	codecList := msdk.Codecs()
 	for _, codec := range codecList {
 		info := codec.Info()
-		t.Run(info.SDPName, func(t *testing.T) {
+		tname := strings.ReplaceAll(info.SDPName, "/", "-")
+		t.Run(tname, func(t *testing.T) {
 			codecs := msdk.NewCodecSet()
 			codecs.SetEnabled(info.SDPName, true)
 
 			sub := strings.SplitN(info.SDPName, "/", 2)
-			name := sub[0]
+			codecName := sub[0]
 			nativeRateSDP, err := strconv.Atoi(sub[1])
 			nativeRate := nativeRateSDP
 			require.NoError(t, err)
-			switch name {
+			switch codecName {
 			case "telephone-event":
 				t.SkipNow()
 			case "G722":
@@ -206,128 +218,184 @@ func TestMediaPort(t *testing.T) {
 						port1 = 10000
 						port2 = 20000
 					)
-					m1, err := NewMediaPortWith(1, log.WithName("one"), newTestCallMonitor(t), c1, &MediaOptions{
+					testRate := tconf.Rate
+					bobToAliceNoResample := testRate == 8000
+
+					alicePort, err := NewMediaPortWith(1, log.WithName("Alice"), newTestCallMonitor(t), c1, &MediaOptions{
 						IP:              newIP(ip1),
 						Ports:           rtcconfig.PortRange{Start: port1},
-						NoInputResample: true,
-					}, tconf.Rate)
+						NoInputResample: bobToAliceNoResample,
+					}, testRate)
 					require.NoError(t, err)
-					defer m1.Close()
+					defer alicePort.Close()
 
-					m2, err := NewMediaPortWith(2, log.WithName("two"), newTestCallMonitor(t), c2, &MediaOptions{
+					bobPort, err := NewMediaPortWith(2, log.WithName("Bob"), newTestCallMonitor(t), c2, &MediaOptions{
 						IP:    newIP(ip2),
 						Ports: rtcconfig.PortRange{Start: port2},
-					}, tconf.Rate)
+					}, testRate)
 					require.NoError(t, err)
-					defer m2.Close()
+					defer bobPort.Close()
 
-					offer, err := m1.NewOffer(codecs, tconf.Encrypted)
+					// Alice sends an offer to Bob
+
+					offer, err := alicePort.NewOffer(codecs, tconf.Encrypted)
 					require.NoError(t, err)
 					offerData, err := offer.SDP.Marshal()
 					require.NoError(t, err)
 
 					t.Logf("SDP offer:\n%s", string(offerData))
 
-					answer, conf, err := m2.SetOffer(offerData, codecs, tconf.Encrypted)
+					answer, bobConf, err := bobPort.SetOffer(offerData, codecs, tconf.Encrypted)
 					require.NoError(t, err)
 					answerData, err := answer.SDP.Marshal()
 					require.NoError(t, err)
 
 					t.Logf("SDP answer:\n%s", string(answerData))
 
-					mc, _, err := m1.SetAnswer(offer, answerData, codecs, tconf.Encrypted)
+					aliceConf, _, err := alicePort.SetAnswer(offer, answerData, codecs, tconf.Encrypted)
 					require.NoError(t, err)
 
-					err = m1.SetConfig(mc)
+					err = alicePort.SetConfig(aliceConf)
 					require.NoError(t, err)
 
-					err = m2.SetConfig(conf)
+					err = bobPort.SetConfig(bobConf)
 					require.NoError(t, err)
 
-					audio1 := m1.Config().Audio
-					audio2 := m2.Config().Audio
-					codec1 := audio1.Codec
-					codec2 := audio2.Codec
-					require.Equal(t, info.SDPName, codec1.Info().SDPName)
-					require.Equal(t, info.SDPName, codec2.Info().SDPName)
+					aliceAudio := alicePort.Config().Audio
+					bobAudio := bobPort.Config().Audio
 
-					var buf1 msdk.PCM16Sample
-					bw1 := msdk.NewPCM16BufferWriter(&buf1, codec1.Info().SampleRate)
-					m1.WriteAudioTo(bw1)
+					aliceCodec := aliceAudio.Codec
+					bobCodec := bobAudio.Codec
 
-					var buf2 msdk.PCM16Sample
-					bw2 := msdk.NewPCM16BufferWriter(&buf2, tconf.Rate)
-					m2.WriteAudioTo(bw2)
+					require.Equal(t, info.SDPName, aliceCodec.Info().SDPName)
+					require.Equal(t, info.SDPName, bobCodec.Info().SDPName)
 
-					w1 := m1.GetAudioWriter()
-					w2 := m2.GetAudioWriter()
+					// Buffers should match the rate of the samples we write.
 
-					packetSize := uint32(tconf.Rate / int(time.Second/rtp.DefFrameDur))
-					sample1 := make(msdk.PCM16Sample, packetSize)
-					sample2 := make(msdk.PCM16Sample, packetSize)
+					var aliceRecvBuf msdk.PCM16Sample
+					aliceHandler := msdk.NewPCM16BufferWriter(&aliceRecvBuf, testRate)
+					alicePort.WriteAudioTo(aliceHandler)
+
+					var bobRecvBuf msdk.PCM16Sample
+					bobHandler := msdk.NewPCM16BufferWriter(&bobRecvBuf, testRate)
+					bobPort.WriteAudioTo(bobHandler)
+
+					aliceToBob := alicePort.GetAudioWriter()
+					bobToAlice := bobPort.GetAudioWriter()
+
+					aliceToBobWriteChain := aliceToBob.String()
+					bobToAliceWriteChain := bobToAlice.String()
+
+					bobToAliceHandleChain := PrintAudioInWriter(alicePort)
+					aliceToBobHandleChain := PrintAudioInWriter(bobPort)
+
+					t.Log("A -> B (write)", aliceToBobWriteChain)
+					t.Log("B -> A (write)", bobToAliceWriteChain)
+
+					t.Log("B -> A (handle)", bobToAliceHandleChain)
+					t.Log("A -> B (handle)", aliceToBobHandleChain)
+
+					t.Log("resample", !bobToAliceNoResample)
+
+					packetSize := testRate / int(time.Second/rtp.DefFrameDur)
+					aliceToBobSamples := make(msdk.PCM16Sample, packetSize)
+					bobToAliceSamples := make(msdk.PCM16Sample, packetSize)
+					const (
+						amp1 = 10000
+						amp2 = 5000
+						freq = 10
+					)
 					for i := range packetSize {
-						sample1[i] = +5116
-						sample2[i] = -5116
+						aliceToBobSamples[i] = int16(amp1 * math.Sin(freq*2*math.Pi*float64(i)/float64(packetSize)))
+						bobToAliceSamples[i] = int16(amp2 * math.Sin(freq*2*math.Pi*float64(i)/float64(packetSize)))
 					}
 
-					writes1 := 1
-					writes2 := 1
+					aliceToBobWrites := 1
+					bobToAliceWrites := 1
 					if tconf.Rate == nativeRate {
 						expChainBase := fmt.Sprintf("Switch(%d) -> LatencyEntry -> %s(encode) -> ByteEncoder(%d) -> StatsWriter(%s/%d) -> LatencyExit",
-							nativeRate, name, nativeRate, name, nativeRateSDP)
-						require.Equal(t, fmt.Sprintf("%s -> RTPWriteStream(%s:%d)", expChainBase, ip2, port2), w1.String())
-						require.Equal(t, fmt.Sprintf("%s -> RTPWriteStream(%s:%d)", expChainBase, ip1, port1), w2.String())
+							nativeRate, codecName, nativeRate, codecName, nativeRateSDP)
+						require.Equal(t, fmt.Sprintf("%s -> RTPWriteStream(%s:%d)", expChainBase, ip2, port2), aliceToBobWriteChain)
+						require.Equal(t, fmt.Sprintf("%s -> RTPWriteStream(%s:%d)", expChainBase, ip1, port1), bobToAliceWriteChain)
 
-						expChainBase = fmt.Sprintf("SilenceFiller(25) -> RTP(%%d) -> ByteDecoder -> %s(decode) -> LatencyExit -> Switch(%d) -> Buffer(%d)", name, nativeRate, nativeRate)
-						require.Equal(t, fmt.Sprintf(expChainBase, audio1.Type), PrintAudioInWriter(m1))
-						require.Equal(t, fmt.Sprintf(expChainBase, audio2.Type), PrintAudioInWriter(m2))
+						expChainBase = fmt.Sprintf("SilenceFiller(25) -> RTP(%%d) -> ByteDecoder -> %s(decode) -> LatencyExit -> Switch(%d) -> Buffer(%d)", codecName, nativeRate, nativeRate)
+						require.Equal(t, fmt.Sprintf(expChainBase, aliceAudio.Type), bobToAliceHandleChain)
+						require.Equal(t, fmt.Sprintf(expChainBase, bobAudio.Type), aliceToBobHandleChain)
 					} else {
 						expChain := fmt.Sprintf("Switch(48000) -> Resample(48000->%d) -> LatencyEntry -> %s(encode) -> ByteEncoder(%d) -> StatsWriter(%s/%d) -> LatencyExit -> SRTPWriteStream",
-							nativeRate, name, nativeRate, name, nativeRateSDP)
-						require.Equal(t, expChain, w1.String())
-						require.Equal(t, expChain, w2.String())
+							nativeRate, codecName, nativeRate, codecName, nativeRateSDP)
+						require.Equal(t, expChain, aliceToBobWriteChain)
+						require.Equal(t, expChain, bobToAliceWriteChain)
 
 						// This side does not resample the received audio, it uses sample rate of the RTP source.
-						expChain1 := fmt.Sprintf("SilenceFiller(25) -> RTP(%d) -> ByteDecoder -> %s(decode) -> LatencyExit -> Switch(%d) -> Buffer(%d)", audio1.Type, name, nativeRate, nativeRate)
+						var expChainAlice string
+						if bobToAliceNoResample {
+							expChainAlice = fmt.Sprintf("SilenceFiller(25) -> RTP(%d) -> ByteDecoder -> %s(decode) -> LatencyExit -> Switch(%d) -> Buffer(%d)", aliceAudio.Type, codecName, nativeRate, nativeRate)
+						} else {
+							expChainAlice = fmt.Sprintf("SilenceFiller(25) -> RTP(%d) -> ByteDecoder -> %s(decode) -> Resample(%d->48000) -> LatencyExit -> Switch(48000) -> Buffer(48000)", aliceAudio.Type, codecName, nativeRate)
+						}
+
 						// This side resamples the received audio to the expected sample rate.
-						expChain2 := fmt.Sprintf("SilenceFiller(25) -> RTP(%d) -> ByteDecoder -> %s(decode) -> Resample(%d->48000) -> LatencyExit -> Switch(48000) -> Buffer(48000)", audio2.Type, name, nativeRate)
-						require.Equal(t, expChain1, PrintAudioInWriter(m1))
-						require.Equal(t, expChain2, PrintAudioInWriter(m2))
+						expChainBob := fmt.Sprintf("SilenceFiller(25) -> RTP(%d) -> ByteDecoder -> %s(decode) -> Resample(%d->48000) -> LatencyExit -> Switch(48000) -> Buffer(48000)", bobAudio.Type, codecName, nativeRate)
 
-						// resampler will buffer a few frames
-						writes1 += 2
-						writes2 += 2
-						// a few more because of higher resample quality required
-						if nativeRate == 8000 {
-							writes1 += 3
-							writes2 += 5
-						}
-						if strings.HasPrefix(info.SDPName, "G722/") {
-							writes2 += 1
-						}
+						require.Equal(t, expChainAlice, bobToAliceHandleChain)
+						require.Equal(t, expChainBob, aliceToBobHandleChain)
 					}
+					// Ramp-up time for the codec.
+					// Some codecs have "inertia" and cannot immediately represent the sound exactly.
+					// This is shy we write signal multiple times to give it some time to adapt.
+					// We will also cut the ramp-up part from the destination buffer before comparing.
+					// This variable is in full frames, so that we clearly see where frames start to calculate the offset below.
+					rampUpFrames := 0
+					// Some codecs have an extra buffering internally, and we have to offset the compared sample
+					// by this number of sampled values.
+					offsetSamples := 0
 
-					for range writes1 {
-						err = w1.WriteSample(sample1)
-						require.NoError(t, err)
+					switch codecName {
+					case "G722":
+						rampUpFrames += 1
+						offsetSamples += 22
+					case "AMR-WB":
+						rampUpFrames += 1
+						offsetSamples += 14 + 16
 					}
-					for range writes2 {
-						err = w2.WriteSample(sample2)
-						require.NoError(t, err)
-					}
+					aliceToBobWrites += rampUpFrames
+					bobToAliceWrites += rampUpFrames
+					discard := rampUpFrames * packetSize
+
+					resampleMult := testRate / nativeRate
+					offsetSamples *= resampleMult
+
+					var wg sync.WaitGroup
+					wg.Add(2)
+					go func() {
+						defer wg.Done()
+						for range aliceToBobWrites {
+							err := aliceToBob.WriteSample(aliceToBobSamples)
+							require.NoError(t, err)
+						}
+					}()
+					go func() {
+						defer wg.Done()
+						for range bobToAliceWrites {
+							err := bobToAlice.WriteSample(bobToAliceSamples)
+							require.NoError(t, err)
+						}
+					}()
+					wg.Wait()
 
 					time.Sleep(time.Second / 4)
 
 					// Cut buffers earlier, otherwise we might get extra samples
 					// that we added to push resampler forward.
-					bw1.Close()
-					bw2.Close()
+					aliceHandler.Close()
+					bobHandler.Close()
 
-					m1.Close()
-					m2.Close()
+					alicePort.Close()
+					bobPort.Close()
 
-					checkPCM(t, sample1, buf2)
-					checkPCM(t, sample2, buf1)
+					checkPCM(t, "A -> B", aliceToBobSamples[:packetSize-offsetSamples], bobRecvBuf[discard+offsetSamples:])
+					checkPCM(t, "B -> A", bobToAliceSamples[:packetSize-offsetSamples], aliceRecvBuf[discard+offsetSamples:])
 				})
 			}
 		})
@@ -335,24 +403,42 @@ func TestMediaPort(t *testing.T) {
 
 }
 
-func checkPCM(t testing.TB, exp, got msdk.PCM16Sample) {
+func checkPCM(t testing.TB, name string, exp, got msdk.PCM16Sample) {
 	t.Helper()
 	require.Equal(t, len(exp), len(got))
-	expSamples := slices.Clone(exp)
-	slices.Sort(expSamples)
-	median := expSamples[len(expSamples)/2]
+
+	minV := slices.Min(exp)
+	maxV := slices.Max(exp)
+
+	// Allow 10% of deviation from original.
 	const perc = 0.1
-	delta := int16(math.Abs(float64(median) * perc))
+	delta := int16(math.Abs(float64(maxV-minV) * perc))
 
 	hits := 0
-	for _, v := range got {
-		if v >= median-delta && v <= median+delta {
+
+	var minD, maxD int16 = math.MaxInt16, 0
+	for i, v := range got {
+		dv := v - exp[i]
+		if dv < 0 {
+			dv = -dv
+		}
+		if dv < delta {
 			hits++
 		}
+		minD = min(minD, dv)
+		maxD = max(maxD, dv)
 	}
+
+	// 90% of the samples should match.
 	const percHit = 0.90
-	expHit := int(float64(len(expSamples)) * percHit)
-	require.True(t, hits >= expHit, "min=%v, max=%v\ngot:\n%v", slices.Min(got), slices.Max(got), got)
+	expHit := int(float64(len(exp)) * percHit)
+	require.True(t, hits >= expHit, "%s: insufficient number of good samples: %v/%v\nminD=%v, maxD=%v, allowed=%v\nmin=%v, max=%v\nexp:\n%v\ngot:\n%v",
+		name,
+		hits, expHit,
+		minD, maxD, delta,
+		slices.Min(got), slices.Max(got),
+		exp, got,
+	)
 }
 
 func newMediaPair(t testing.TB, opt1, opt2 *MediaOptions) (m1, m2 *MediaPort) {


### PR DESCRIPTION
Add support for AMR-WB codec. It can be enabled by specifying `MediaConfig` with `AMR-WB/16000` codec in the dispatch rule or `CreateSIPParticipant`.