### PR TITLE
fix(inbound): send 503 on DispatchNoRuleDrop instead of silently dropping

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -820,7 +820,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		return psrpc.NewError(psrpc.Unimplemented, err)
 	case DispatchNoRuleDrop:
 		c.log().Debugw("Rejecting inbound flood")
-		c.cc.Drop()
+		c.cc.RespondAndDrop(sip.StatusServiceUnavailable, "Service Unavailable")
 		c.close(ctx, callFlood, stats.ClientError("flood"))
 		return psrpc.NewErrorf(psrpc.PermissionDenied, "call was not authorized by trunk configuration")
 	case DispatchNoRuleReject:


### PR DESCRIPTION
## Problem

When the dispatch layer returns `DispatchNoRuleDrop` (no matching dispatch rule, or a server-side DROP decision), `handleInvite` calls `cc.Drop()` which terminates the SIP transaction **without sending any SIP response**. However, by the time the dispatch result is evaluated, livekit-sip has already sent `100 Trying` and `180 Ringing` to the carrier, so the call's existence is already revealed.

The result: the caller hears **indefinite ringing**. The carrier never receives a final response, keeps the INVITE transaction alive, and only terminates when the caller manually hangs up and a CANCEL arrives. This wastes carrier resources and produces confusing UX.

**Observed via SIP trace (Homer/HEP):**
```
+0.000s  INVITE (carrier → kamailio → livekit-sip)
+0.005s  100 Trying
+0.015s  180 Ringing
+0.077s  [livekit-sip closes with 486/flood — no SIP response sent]
+13.1s   CANCEL (caller gave up and hung up)
```

livekit-sip logs showed `Closing inbound call / status=486 / reason=flood` with **no subsequent `Inbound call closed` entry**, confirming the SIP response was never transmitted. The `close()` call after `Drop()` calls `CloseWithStatus()`, which checks `inviteTx != nil` to send the response — but `Drop()` already set `inviteTx = nil`, so no response is sent.

## Fix

Replace `cc.Drop()` with `cc.RespondAndDrop(sip.StatusServiceUnavailable, "Service Unavailable")` — the same pattern used by `DispatchNoRuleReject` and `DispatchServiceUnavailable`.

`RespondAndDrop` sends the final response first, *then* terminates the transaction, so `close()` / `CloseWithStatus()` correctly becomes a no-op.

## Why 503 and not silent drop?

The intent of `DispatchNoRuleDrop` appears to be "don't reveal endpoint information." However, since `100 Trying` and `180 Ringing` are already sent before dispatch runs, the endpoint's existence is already revealed by the time `Drop()` is called. Sending a `503` at this point leaks no additional information, but it immediately terminates the call at the carrier side instead of leaving it hanging.

The auth-level `AuthDrop` (which fires before any provisional response is sent) is a different case and correctly remains a silent drop.

## Testing

Reproduce by removing all dispatch rules for a DID, calling it, and observing the caller experience before/after this fix:
- **Before**: caller hears ringing indefinitely until they hang up
- **After**: call immediately fails with 503 Service Unavailable