### PR TITLE
TEL-588: treat cps limit exceeded error as client error

### DIFF
--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -116,8 +117,21 @@ func classifyInviteError(err error) inviteFailure {
 				res.status, res.term, res.reason = callRejected, stats.ClientError(fmt.Sprintf("client-error-%d", code)), livekit.DisconnectReason_USER_UNAVAILABLE
 				res.reportErr = nil
 			case code >= 500 && code < 600:
-				res.status, res.term, res.reason = callDropped, stats.ServerError(fmt.Sprintf("upstream-server-error-%d", code)), livekit.DisconnectReason_SIP_TRUNK_FAILURE
-				// keep reportErr so 5xx detail is recorded
+				// Some upstreams (notably Twilio) return a 5xx when the customer's own trunk exceeds its configured CPS or
+				// concurrent-call cap. That's a customer-side rate limit, not upstream infrastructure breakage, so it must not count
+				// against the server-error SLI. Match on the response body — brittle, so kept narrow to the known phrases.
+				body := strings.ToLower(sipStatus.GetStatus())
+				switch {
+				case strings.Contains(body, "cps limit exceeded"):
+					res.status, res.term, res.reason = callRejected, stats.ClientError("cps-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
+					// keep reportErr so the customer can see they hit their cap
+				case strings.Contains(body, "concurrent call limit exceeded"):
+					res.status, res.term, res.reason = callRejected, stats.ClientError("concurrent-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
+					// keep reportErr so the customer can see they hit their cap
+				default:
+					res.status, res.term, res.reason = callDropped, stats.ServerError(fmt.Sprintf("upstream-server-error-%d", code)), livekit.DisconnectReason_SIP_TRUNK_FAILURE
+					// keep reportErr so 5xx detail is recorded
+				}
 			case code >= 600 && code < 700:
 				res.status, res.term, res.reason = callRejected, stats.ClientError(fmt.Sprintf("global-decline-%d", code)), livekit.DisconnectReason_USER_REJECTED
 				res.reportErr = nil

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -23,6 +23,12 @@ func TestClassifyInviteError(t *testing.T) {
 			Status: "test",
 		})
 	}
+	sipStatusBodyErr := func(code int, body string) error {
+		return fmt.Errorf("unexpected status from INVITE response: %w", &livekit.SIPStatus{
+			Code:   livekit.SIPStatusCode(code),
+			Status: body,
+		})
+	}
 
 	cases := []struct {
 		name       string
@@ -49,6 +55,12 @@ func TestClassifyInviteError(t *testing.T) {
 		// 5xx upstream server error
 		{"500 Internal Server Error", sipStatusErr(500), callDropped, stats.ServerError("upstream-server-error-500"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 		{"503 Service Unavailable", sipStatusErr(503), callDropped, stats.ServerError("upstream-server-error-503"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+
+		// 5xx with a trunk rate-limit body: customer-side, reclassified as client_error
+		{"500 Trunk CPS limit exceeded", sipStatusBodyErr(500, "Trunk CPS limit exceeded. Region: us1"), callRejected, stats.ClientError("cps-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"500 Trunk concurrent call limit exceeded", sipStatusBodyErr(500, "Trunk concurrent call limit exceeded. Region: us1"), callRejected, stats.ClientError("concurrent-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"503 Trunk CPS limit exceeded", sipStatusBodyErr(503, "Trunk CPS limit exceeded. Region: us1"), callRejected, stats.ClientError("cps-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"500 generic body is not a rate limit", sipStatusBodyErr(500, "Service Unavailable"), callDropped, stats.ServerError("upstream-server-error-500"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 
 		// 6xx global decline
 		{"600 Global Busy Everywhere", sipStatusErr(600), callRejected, stats.ClientError("global-decline-600"), livekit.DisconnectReason_USER_REJECTED, false},


### PR DESCRIPTION
this is needed to keep call completion rate for outbound calls above 95% constantly