### PR TITLE
fix symmetric rtp

### DIFF
--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -714,7 +714,7 @@ func (p *MediaPort) SetConfig(c *MediaConf) error {
 		"srtp", crypto,
 	)
 
-	symmetric := p.opts.IgnoreLocalAddrInSDP && c.Remote.Addr().IsPrivate()
+	symmetric := p.opts.SymmetricRTP || (p.opts.IgnoreLocalAddrInSDP && c.Remote.Addr().IsPrivate())
 	p.port.SetDst(c.Remote)
 	if symmetric {
 		p.port.SetSymmetric(true)
@@ -739,9 +739,6 @@ func (p *MediaPort) SetConfig(c *MediaConf) error {
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if !symmetric {
-		p.port.SetDst(c.Remote)
-	}
 	p.conf = c
 	p.sess = sess
 


### PR DESCRIPTION
I think the [original implementation](https://github.com/livekit/sip/commit/afd7dd4edf05edfeb4a7553b8f5341ad88ee6c44) broken now that we [introduced IgnoreLocalAddrInSDP](https://github.com/livekit/sip/commit/bab77e1593b8018866b01a9afa05f2873f212da5). I don't see anywhere we actually use SymmetricRTP.