### PR TITLE
TEL-588: categorize timer B transaction timeout for outbound call

### DIFF
--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -70,6 +70,33 @@ func (e SDPError) ClassifyInvite() inviteFailure {
 	return res
 }
 
+// transactionTimeoutError is an INVITE transaction that terminated without a
+// final response. responses = 1xx provisionals seen first: 0 = upstream went
+// silent (Timer B), >0 = answered but never completed.
+type transactionTimeoutError struct {
+	responses int
+}
+
+var _ inviteClassifier = transactionTimeoutError{}
+
+func (e transactionTimeoutError) Error() string {
+	return fmt.Sprintf("transaction failed to complete (%d intermediate responses)", e.responses)
+}
+
+func (e transactionTimeoutError) ClassifyInvite() inviteFailure {
+	reason := "upstream-no-response"
+	if e.responses > 0 {
+		reason = "no-final-response"
+	}
+	return inviteFailure{
+		status:    callUnavailable,
+		term:      stats.ClientError(reason),
+		reason:    livekit.DisconnectReason_SIP_TRUNK_FAILURE,
+		reportErr: e, // keep so the customer sees their destination didn't complete
+		returnErr: psrpc.NewError(psrpc.Canceled, e),
+	}
+}
+
 // classifyInviteError buckets an outbound INVITE error. Self-classifying
 // errors describe themselves; the residual switch covers external types we
 // can't extend (SIPStatus, net.*, context.*) and falls back to

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -73,6 +73,8 @@ func TestClassifyInviteError(t *testing.T) {
 
 		// Sentinel-based errors
 		{"SIP request timeout (no answer)", psrpc.NewError(psrpc.Canceled, ErrSIPRequestTimeout), callUnavailable, stats.ClientError("no-answer"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
+		{"SIP transaction timeout (silent, cnt=0)", psrpc.NewError(psrpc.Canceled, transactionTimeoutError{responses: 0}), callUnavailable, stats.ClientError("upstream-no-response"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"SIP transaction timeout (no final, cnt>0)", psrpc.NewError(psrpc.Canceled, transactionTimeoutError{responses: 2}), callUnavailable, stats.ClientError("no-final-response"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 		{"Auth max retry", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthMaxRetry), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},
 		{"Auth missing creds", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthMissingCreds), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},
 		{"Auth no header", psrpc.NewError(psrpc.FailedPrecondition, ErrAuthNoHeader), callRejected, stats.ClientError("auth-failed"), livekit.DisconnectReason_USER_REJECTED, true},

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -502,7 +502,7 @@ func sipResponse(ctx context.Context, tx sip.ClientTransaction, stop <-chan stru
 			_ = tx.Cancel()
 			return nil, psrpc.NewErrorf(psrpc.Canceled, "service shutting down")
 		case <-tx.Done():
-			return nil, psrpc.NewErrorf(psrpc.Canceled, "transaction failed to complete (%d intermediate responses)", cnt)
+			return nil, psrpc.NewError(psrpc.Canceled, transactionTimeoutError{responses: cnt})
 		case res := <-tx.Responses():
 			status := res.StatusCode
 			if setState != nil {


### PR DESCRIPTION
This is client error, not server error.