### PR TITLE
TEL-588: separate indeterminate and upstreamerror from server error

### DIFF
--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -129,8 +129,8 @@ func classifyInviteError(err error) inviteFailure {
 					res.status, res.term, res.reason = callRejected, stats.ClientError("concurrent-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE
 					// keep reportErr so the customer can see they hit their cap
 				default:
-					res.status, res.term, res.reason = callDropped, stats.ServerError(fmt.Sprintf("upstream-server-error-%d", code)), livekit.DisconnectReason_SIP_TRUNK_FAILURE
-					// keep reportErr so 5xx detail is recorded
+					// Carrier-side 5xx; keep reportErr for the detail.
+					res.status, res.term, res.reason = callDropped, stats.UpstreamError(fmt.Sprintf("upstream-server-error-%d", code)), livekit.DisconnectReason_SIP_TRUNK_FAILURE
 				}
 			case code >= 600 && code < 700:
 				res.status, res.term, res.reason = callRejected, stats.ClientError(fmt.Sprintf("global-decline-%d", code)), livekit.DisconnectReason_USER_REJECTED

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -53,14 +53,14 @@ func TestClassifyInviteError(t *testing.T) {
 		{"487 Request Terminated (4xx catch-all)", sipStatusErr(487), callRejected, stats.ClientError("client-error-487"), livekit.DisconnectReason_USER_UNAVAILABLE, false},
 
 		// 5xx upstream server error
-		{"500 Internal Server Error", sipStatusErr(500), callDropped, stats.ServerError("upstream-server-error-500"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
-		{"503 Service Unavailable", sipStatusErr(503), callDropped, stats.ServerError("upstream-server-error-503"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"500 Internal Server Error", sipStatusErr(500), callDropped, stats.UpstreamError("upstream-server-error-500"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"503 Service Unavailable", sipStatusErr(503), callDropped, stats.UpstreamError("upstream-server-error-503"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 
 		// 5xx with a trunk rate-limit body: customer-side, reclassified as client_error
 		{"500 Trunk CPS limit exceeded", sipStatusBodyErr(500, "Trunk CPS limit exceeded. Region: us1"), callRejected, stats.ClientError("cps-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 		{"500 Trunk concurrent call limit exceeded", sipStatusBodyErr(500, "Trunk concurrent call limit exceeded. Region: us1"), callRejected, stats.ClientError("concurrent-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 		{"503 Trunk CPS limit exceeded", sipStatusBodyErr(503, "Trunk CPS limit exceeded. Region: us1"), callRejected, stats.ClientError("cps-limit-exceeded"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
-		{"500 generic body is not a rate limit", sipStatusBodyErr(500, "Service Unavailable"), callDropped, stats.ServerError("upstream-server-error-500"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
+		{"500 generic body is not a rate limit", sipStatusBodyErr(500, "Service Unavailable"), callDropped, stats.UpstreamError("upstream-server-error-500"), livekit.DisconnectReason_SIP_TRUNK_FAILURE, true},
 
 		// 6xx global decline
 		{"600 Global Busy Everywhere", sipStatusErr(600), callRejected, stats.ClientError("global-decline-600"), livekit.DisconnectReason_USER_REJECTED, false},

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1331,7 +1331,7 @@ func (c *inboundCall) closeWithTimeout(ctx context.Context, isError bool) {
 			}
 		})
 	}
-	c.close(ctx, status, stats.ServerError("media-timeout"))
+	c.close(ctx, status, stats.Indeterminate("media-timeout"))
 }
 
 func (c *inboundCall) closeWithNoACK(ctx context.Context) {

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -307,7 +307,7 @@ func (c *outboundCall) CloseWithReason(ctx context.Context, status CallStatus, t
 func (c *outboundCall) closeWithTimeout(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.close(ctx, psrpc.NewErrorf(psrpc.DeadlineExceeded, "media-timeout"), callDropped, stats.ServerError("media-timeout"), livekit.DisconnectReason_UNKNOWN_REASON)
+	c.close(ctx, psrpc.NewErrorf(psrpc.DeadlineExceeded, "media-timeout"), callDropped, stats.Indeterminate("media-timeout"), livekit.DisconnectReason_UNKNOWN_REASON)
 }
 
 func (c *outboundCall) printStats() {

--- a/pkg/stats/termination.go
+++ b/pkg/stats/termination.go
@@ -20,6 +20,10 @@ const (
 	ResultSuccess     TerminationResult = "success"
 	ResultServerError TerminationResult = "server_error"
 	ResultClientError TerminationResult = "client_error"
+	// Unattributable failure (e.g. media timeout)
+	ResultIndeterminate TerminationResult = "indeterminate"
+	// Upstream carrier/trunk 5xx
+	ResultUpstreamError TerminationResult = "upstream_error"
 )
 
 type Termination struct {
@@ -33,4 +37,10 @@ func ServerError(reason string) Termination {
 }
 func ClientError(reason string) Termination {
 	return Termination{Result: ResultClientError, Reason: reason}
+}
+func Indeterminate(reason string) Termination {
+	return Termination{Result: ResultIndeterminate, Reason: reason}
+}
+func UpstreamError(reason string) Termination {
+	return Termination{Result: ResultUpstreamError, Reason: reason}
 }


### PR DESCRIPTION
include upstream 5xx in server_error is too noisy..