### PR TITLE
sip: redirect RTP destination on re-INVITE port change

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -312,6 +312,14 @@ func (s *Server) handleInviteAuth(tid traceid.ID, log logger.Logger, req *sip.Re
 	return true, false
 }
 
+func sdpBodyFromRequest(req *sip.Request) []byte {
+	ct := req.ContentType()
+	if ct != nil && ct.Value() != "application/sdp" {
+		return nil
+	}
+	return req.Body()
+}
+
 func updateRemoteFromSDP(media *MediaPort, log logger.Logger, body []byte) {
 	if len(body) == 0 || media == nil {
 		return
@@ -393,7 +401,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
 		existing.log().Infow("reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-		updateRemoteFromSDP(existing.media, existing.log(), req.Body())
+		updateRemoteFromSDP(existing.media, existing.log(), sdpBodyFromRequest(req))
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
 	}
@@ -404,7 +412,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 			localSDP := oc.cc.LocalSDP()
 			if len(localSDP) != 0 {
 				oc.log.Infow("accepting reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-				updateRemoteFromSDP(oc.media, oc.log, req.Body())
+				updateRemoteFromSDP(oc.media, oc.log, sdpBodyFromRequest(req))
 				oc.cc.RecordInvite(newCSeq)
 				cc.AcceptAsKeepAlive(localSDP)
 				return nil

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -382,7 +382,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
 		existing.log().Infow("reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 		if body := req.Body(); len(body) != 0 && existing.media != nil {
-			if desc, err := sdp.Parse(body); err == nil {
+			if desc, err := sdp.ParseWith(msdk.GlobalCodecs(), body); err == nil {
 				existing.media.UpdateRemote(desc.Addr)
 			} else {
 				existing.log().Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)
@@ -399,7 +399,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 			if len(localSDP) != 0 {
 				oc.log.Infow("accepting reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 				if body := req.Body(); len(body) != 0 && oc.media != nil {
-					if desc, err := sdp.Parse(body); err == nil {
+					if desc, err := sdp.ParseWith(msdk.GlobalCodecs(), body); err == nil {
 						oc.media.UpdateRemote(desc.Addr)
 					} else {
 						oc.log.Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -381,6 +381,13 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
 		existing.log().Infow("reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
+		if body := req.Body(); len(body) != 0 && existing.media != nil {
+			if desc, err := sdp.Parse(body); err == nil {
+				existing.media.UpdateRemote(desc.Addr)
+			} else {
+				existing.log().Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)
+			}
+		}
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
 	}

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -320,11 +320,11 @@ func sdpBodyFromRequest(req *sip.Request) []byte {
 	return req.Body()
 }
 
-func updateRemoteFromSDP(media *MediaPort, log logger.Logger, body []byte) {
+func updateRemoteFromSDP(media *MediaPort, log logger.Logger, codecs *msdk.CodecSet, body []byte) {
 	if len(body) == 0 || media == nil {
 		return
 	}
-	desc, err := sdp.ParseWith(msdk.GlobalCodecs(), body)
+	desc, err := sdp.ParseWith(codecs, body)
 	if err != nil {
 		log.Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)
 		return
@@ -401,7 +401,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
 		existing.log().Infow("reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-		updateRemoteFromSDP(existing.media, existing.log(), sdpBodyFromRequest(req))
+		existing.updateRemoteFromSDP(sdpBodyFromRequest(req))
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
 	}
@@ -412,7 +412,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 			localSDP := oc.cc.LocalSDP()
 			if len(localSDP) != 0 {
 				oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-				updateRemoteFromSDP(oc.media, oc.log, sdpBodyFromRequest(req))
+				oc.updateRemoteFromSDP(sdpBodyFromRequest(req))
 				oc.cc.RecordInvite(newCSeq)
 				cc.AcceptAsKeepAlive(localSDP)
 				return nil
@@ -690,6 +690,7 @@ type inboundCall struct {
 	call        *rpc.SIPCall
 	mmu         sync.Mutex
 	media       *MediaPort
+	mediaCodecs *msdk.CodecSet
 	dtmf        chan dtmf.Event // buffered
 	lkRoom      RoomInterface   // LiveKit room; only active after correct pin is entered
 	callDur     func() time.Duration
@@ -1095,6 +1096,7 @@ func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, mconf *sipM
 		return nil, err
 	}
 	c.media = mp
+	c.mediaCodecs = mconf.Codecs
 	mp.EnableTimeout(false) // enabled once we accept the call
 	mp.DisableOut()         // disabled until we send 200
 	mp.SetDTMFAudio(conf.AudioDTMF)
@@ -1409,6 +1411,12 @@ func (c *inboundCall) Close() error {
 // close() is idempotent via c.done, so concurrent paths cannot double-emit.
 func (c *inboundCall) Shutdown(ctx context.Context) {
 	c.close(ctx, callDropped, stats.ServerError("shutdown"))
+}
+
+func (c *inboundCall) updateRemoteFromSDP(body []byte) {
+	c.mmu.Lock()
+	defer c.mmu.Unlock()
+	updateRemoteFromSDP(c.media, c.log(), c.mediaCodecs, body)
 }
 
 func (c *inboundCall) closeMedia() {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -312,6 +312,18 @@ func (s *Server) handleInviteAuth(tid traceid.ID, log logger.Logger, req *sip.Re
 	return true, false
 }
 
+func updateRemoteFromSDP(media *MediaPort, log logger.Logger, body []byte) {
+	if len(body) == 0 || media == nil {
+		return
+	}
+	desc, err := sdp.ParseWith(msdk.GlobalCodecs(), body)
+	if err != nil {
+		log.Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)
+		return
+	}
+	media.UpdateRemote(desc.Addr)
+}
+
 func (s *Server) onInvite(log *slog.Logger, req *sip.Request, tx sip.ServerTransaction) {
 	// Error processed in defer
 	_ = s.processInvite(req, tx)
@@ -381,13 +393,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
 		existing.log().Infow("reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-		if body := req.Body(); len(body) != 0 && existing.media != nil {
-			if desc, err := sdp.ParseWith(msdk.GlobalCodecs(), body); err == nil {
-				existing.media.UpdateRemote(desc.Addr)
-			} else {
-				existing.log().Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)
-			}
-		}
+		updateRemoteFromSDP(existing.media, existing.log(), req.Body())
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
 	}
@@ -398,13 +404,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 			localSDP := oc.cc.LocalSDP()
 			if len(localSDP) != 0 {
 				oc.log.Infow("accepting reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-				if body := req.Body(); len(body) != 0 && oc.media != nil {
-					if desc, err := sdp.ParseWith(msdk.GlobalCodecs(), body); err == nil {
-						oc.media.UpdateRemote(desc.Addr)
-					} else {
-						oc.log.Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)
-					}
-				}
+				updateRemoteFromSDP(oc.media, oc.log, req.Body())
 				oc.cc.RecordInvite(newCSeq)
 				cc.AcceptAsKeepAlive(localSDP)
 				return nil

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -395,11 +395,18 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 		oc := s.cli.getActiveCall(cc.ID())
 		newCSeq := cc.InviteCSeq()
 		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq {
-			sdp := oc.cc.LocalSDP()
-			if len(sdp) != 0 {
+			localSDP := oc.cc.LocalSDP()
+			if len(localSDP) != 0 {
 				oc.log.Infow("accepting reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
+				if body := req.Body(); len(body) != 0 && oc.media != nil {
+					if desc, err := sdp.Parse(body); err == nil {
+						oc.media.UpdateRemote(desc.Addr)
+					} else {
+						oc.log.Warnw("failed to parse re-INVITE SDP, RTP destination not updated", err)
+					}
+				}
 				oc.cc.RecordInvite(newCSeq)
-				cc.AcceptAsKeepAlive(sdp)
+				cc.AcceptAsKeepAlive(localSDP)
 				return nil
 			}
 		}

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -400,7 +400,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	existing := s.byLocalTag[cc.ID()]
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
-		existing.log().Infow("reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
+		existing.log().Infow("reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 		updateRemoteFromSDP(existing.media, existing.log(), sdpBodyFromRequest(req))
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
@@ -411,7 +411,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq {
 			localSDP := oc.cc.LocalSDP()
 			if len(localSDP) != 0 {
-				oc.log.Infow("accepting reinvite", "content-type", req.ContentType(), "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
+				oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 				updateRemoteFromSDP(oc.media, oc.log, sdpBodyFromRequest(req))
 				oc.cc.RecordInvite(newCSeq)
 				cc.AcceptAsKeepAlive(localSDP)

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -630,6 +630,20 @@ func (p *MediaPort) Port() int {
 	return p.port.LocalAddr().(*net.UDPAddr).Port
 }
 
+func (p *MediaPort) RemoteAddr() netip.AddrPort {
+	dst := p.port.dst.Load()
+	if dst == nil {
+		return netip.AddrPort{}
+	}
+	return *dst
+}
+
+func (p *MediaPort) UpdateRemote(addr netip.AddrPort) {
+	if addr.IsValid() {
+		p.port.SetDst(addr)
+	}
+}
+
 func (p *MediaPort) Received() <-chan struct{} {
 	return p.mediaReceived.Watch()
 }

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -639,7 +639,7 @@ func (p *MediaPort) RemoteAddr() netip.AddrPort {
 }
 
 func (p *MediaPort) UpdateRemote(addr netip.AddrPort) {
-	if addr.IsValid() {
+	if addr.IsValid() && !addr.Addr().IsUnspecified() {
 		p.port.SetDst(addr)
 	}
 }

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -257,7 +257,7 @@ func (c *udpConn) Read(b []byte) (n int, err error) {
 	n, addr, err := c.ReadFromUDPAddrPort(b)
 	prev := c.src.Swap(&addr)
 	if prev == nil || !prev.IsValid() {
-		c.log.Infow("setting media source", "prev", prev, "addr", addr.String())
+		c.log.Infow("setting media source", "prev", netip.AddrPort{}, "addr", addr.String())
 	} else if *prev != addr {
 		changeCount := c.srcChangeCount.Add(1)
 		now := time.Now().UnixNano()

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -241,7 +241,7 @@ func (c *udpConn) SetDst(addr netip.AddrPort) {
 	if addr.IsValid() {
 		prev := c.dst.Swap(&addr)
 		if prev == nil || !prev.IsValid() {
-			c.log.Infow("setting media destination", "prev", prev, "addr", addr.String())
+			c.log.Infow("setting media destination", "prev", netip.AddrPort{}, "addr", addr.String())
 		} else if *prev != addr {
 			changeCount := c.dstChangeCount.Add(1)
 			now := time.Now().UnixNano()

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -241,7 +241,7 @@ func (c *udpConn) SetDst(addr netip.AddrPort) {
 	if addr.IsValid() {
 		prev := c.dst.Swap(&addr)
 		if prev == nil || !prev.IsValid() {
-			c.log.Infow("setting media destination", "prev", netip.AddrPort{}, "addr", addr.String())
+			c.log.Infow("setting media destination", "addr", addr.String())
 		} else if *prev != addr {
 			changeCount := c.dstChangeCount.Add(1)
 			now := time.Now().UnixNano()
@@ -257,7 +257,7 @@ func (c *udpConn) Read(b []byte) (n int, err error) {
 	n, addr, err := c.ReadFromUDPAddrPort(b)
 	prev := c.src.Swap(&addr)
 	if prev == nil || !prev.IsValid() {
-		c.log.Infow("setting media source", "prev", netip.AddrPort{}, "addr", addr.String())
+		c.log.Infow("setting media source", "addr", addr.String())
 	} else if *prev != addr {
 		changeCount := c.srcChangeCount.Add(1)
 		now := time.Now().UnixNano()

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -188,6 +188,10 @@ func TestMediaPortUpdateRemote(t *testing.T) {
 	// UpdateRemote with invalid addr should be a no-op.
 	mp.UpdateRemote(netip.AddrPort{})
 	require.Equal(t, addr, mp.RemoteAddr(), "UpdateRemote with invalid addr should not change RemoteAddr")
+
+	// UpdateRemote with unspecified address (c=0.0.0.0 hold form) should be a no-op.
+	mp.UpdateRemote(netip.MustParseAddrPort("0.0.0.0:12345"))
+	require.Equal(t, addr, mp.RemoteAddr(), "UpdateRemote with unspecified addr should not change RemoteAddr")
 }
 
 func TestMediaPort(t *testing.T) {

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -165,6 +165,31 @@ func newIP(v string) netip.Addr {
 	return ip
 }
 
+func TestMediaPortUpdateRemote(t *testing.T) {
+	log := logger.GetLogger()
+	mon := newTestCallMonitor(t)
+
+	// newUDPPipe wires two in-memory testUDPConn together.
+	c1, _ := newUDPPipe()
+	mp, err := NewMediaPortWith(1, log, mon, c1, &MediaOptions{
+		IP: netip.MustParseAddr("127.0.0.1"),
+	}, 8000)
+	require.NoError(t, err)
+	defer mp.Close()
+
+	// Initially no destination is set.
+	require.False(t, mp.RemoteAddr().IsValid(), "RemoteAddr should be invalid before any update")
+
+	// Update to a valid address.
+	addr := netip.MustParseAddrPort("9.8.7.6:12345")
+	mp.UpdateRemote(addr)
+	require.Equal(t, addr, mp.RemoteAddr(), "RemoteAddr should reflect the updated address")
+
+	// UpdateRemote with invalid addr should be a no-op.
+	mp.UpdateRemote(netip.AddrPort{})
+	require.Equal(t, addr, mp.RemoteAddr(), "UpdateRemote with invalid addr should not change RemoteAddr")
+}
+
 func TestMediaPort(t *testing.T) {
 	// Main resampler has unpredictable (although tiny) output delay
 	// and other randomness in the generated samples.

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -467,6 +467,10 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 	return nil
 }
 
+func (c *outboundCall) updateRemoteFromSDP(body []byte) {
+	updateRemoteFromSDP(c.media, c.log, c.sipConf.mediaConfig.Codecs, body)
+}
+
 func (c *outboundCall) connectMedia() {
 	if w := c.lkRoom.SwapOutput(c.media.GetAudioWriter()); w != nil {
 		_ = w.Close()

--- a/pkg/sip/signaling_test.go
+++ b/pkg/sip/signaling_test.go
@@ -663,11 +663,7 @@ func TestReinvite(t *testing.T) {
 			require.Equal(t, serverLocalSDP, resp.Body(), "reinvite 200 OK should return server local SDP")
 
 			// After the re-INVITE with new offer, the media port destination must be updated.
-			require.Equal(t,
-				netip.MustParseAddrPort("9.8.7.6:12345"),
-				ic.media.RemoteAddr(),
-				"re-INVITE should redirect RTP to the new remote address",
-			)
+			require.Equal(t, newOffer.Addr, ic.media.RemoteAddr(), "re-INVITE should redirect RTP to the new remote address")
 		})
 
 		t.Run("miss", func(t *testing.T) {
@@ -698,8 +694,7 @@ func TestReinvite(t *testing.T) {
 			initialRemote := ic.media.RemoteAddr()
 
 			// Re-INVITE with no SDP body — destination must not change.
-			req, _, err := call.Invite(nil)
-			require.NoError(t, err)
+			req := call.NewRequest(sip.INVITE) // no body, no Content-Type
 			resp := st.TestUA.TransactionRequest(t, req, true)
 			require.Equal(t, sip.StatusCode(200), resp.StatusCode, "body-less re-INVITE should still get 200 OK")
 			require.Equal(t, serverLocalSDP, resp.Body(), "body-less re-INVITE should return server local SDP")
@@ -732,11 +727,21 @@ func TestReinvite(t *testing.T) {
 			require.Equal(t, serverLocalSDP, resp.Body(), "reinvite 200 OK should return server local SDP")
 
 			// After the re-INVITE with new offer, the media port destination must be updated.
-			require.Equal(t,
-				netip.MustParseAddrPort("9.8.7.6:12345"),
-				oc.media.RemoteAddr(),
-				"re-INVITE should redirect outbound call RTP to the new remote address",
-			)
+			require.Equal(t, newOffer.Addr, oc.media.RemoteAddr(), "re-INVITE should redirect outbound call RTP to the new remote address")
+		})
+
+		t.Run("no_body", func(t *testing.T) {
+			st := NewServiceTest(t, nil)
+			call, oc, _ := st.CreateOutboundCall(t)
+			serverLocalSDP := oc.cc.LocalSDP()
+			initialRemote := oc.media.RemoteAddr()
+
+			// Re-INVITE with no SDP body — destination must not change.
+			req := call.NewRequest(sip.INVITE) // no body, no Content-Type
+			resp := st.TestUA.TransactionRequest(t, req, false)
+			require.Equal(t, sip.StatusCode(200), resp.StatusCode, "body-less re-INVITE should still get 200 OK")
+			require.Equal(t, serverLocalSDP, resp.Body(), "body-less re-INVITE should return server local SDP")
+			require.Equal(t, initialRemote, oc.media.RemoteAddr(), "body-less re-INVITE must not change RTP destination")
 		})
 
 		t.Run("miss", func(t *testing.T) {

--- a/pkg/sip/signaling_test.go
+++ b/pkg/sip/signaling_test.go
@@ -715,6 +715,13 @@ func TestReinvite(t *testing.T) {
 			resp = st.TestUA.TransactionRequest(t, req, false)
 			require.Equal(t, sip.StatusCode(200), resp.StatusCode, "reinvite for outbound call should get 200 OK")
 			require.Equal(t, serverLocalSDP, resp.Body(), "reinvite 200 OK should return server local SDP")
+
+			// After the re-INVITE with new offer, the media port destination must be updated.
+			require.Equal(t,
+				netip.MustParseAddrPort("9.8.7.6:12345"),
+				oc.media.RemoteAddr(),
+				"re-INVITE should redirect outbound call RTP to the new remote address",
+			)
 		})
 
 		t.Run("miss", func(t *testing.T) {

--- a/pkg/sip/signaling_test.go
+++ b/pkg/sip/signaling_test.go
@@ -641,7 +641,7 @@ func TestReinvite(t *testing.T) {
 	t.Run("inbound", func(t *testing.T) {
 		t.Run("normal", func(t *testing.T) {
 			st := NewServiceTest(t, nil)
-			call, _ := st.CreateInboundCall(t)
+			call, ic := st.CreateInboundCall(t)
 			serverLocalSDP := call.remoteSDP
 
 			// Re-INVITE
@@ -661,6 +661,13 @@ func TestReinvite(t *testing.T) {
 			resp = st.TestUA.TransactionRequest(t, req, true)
 			require.Equal(t, sip.StatusCode(200), resp.StatusCode, "reinvite for outbound call should get 200 OK")
 			require.Equal(t, serverLocalSDP, resp.Body(), "reinvite 200 OK should return server local SDP")
+
+			// After the re-INVITE with new offer, the media port destination must be updated.
+			require.Equal(t,
+				netip.MustParseAddrPort("9.8.7.6:12345"),
+				ic.media.RemoteAddr(),
+				"re-INVITE should redirect RTP to the new remote address",
+			)
 		})
 
 		t.Run("miss", func(t *testing.T) {

--- a/pkg/sip/signaling_test.go
+++ b/pkg/sip/signaling_test.go
@@ -690,6 +690,21 @@ func TestReinvite(t *testing.T) {
 			require.Equal(t, sip.StatusCode(200), resp.StatusCode, "reinvite for outbound call should get 200 OK")
 			require.NotEqual(t, serverLocalSDP, resp.Body(), "reinvite for new call should return new server local SDP")
 		})
+
+		t.Run("no_body", func(t *testing.T) {
+			st := NewServiceTest(t, nil)
+			call, ic := st.CreateInboundCall(t)
+			serverLocalSDP := call.remoteSDP
+			initialRemote := ic.media.RemoteAddr()
+
+			// Re-INVITE with no SDP body — destination must not change.
+			req, _, err := call.Invite(nil)
+			require.NoError(t, err)
+			resp := st.TestUA.TransactionRequest(t, req, true)
+			require.Equal(t, sip.StatusCode(200), resp.StatusCode, "body-less re-INVITE should still get 200 OK")
+			require.Equal(t, serverLocalSDP, resp.Body(), "body-less re-INVITE should return server local SDP")
+			require.Equal(t, initialRemote, ic.media.RemoteAddr(), "body-less re-INVITE must not change RTP destination")
+		})
 	})
 	t.Run("outbound", func(t *testing.T) {
 		t.Run("normal", func(t *testing.T) {


### PR DESCRIPTION
## Problem

When a SIP carrier sends a mid-call re-INVITE with a new RTP port (e.g. after a NAT rebind or media relay failover), LiveKit SIP was responding 200 OK but continuing to send RTP to the stale address — violating [RFC 3264 §8](https://www.rfc-editor.org/rfc/rfc3264#section-8), which requires the answerer to direct media to the address/port in the new offer.

Closes #661

## What changed

**`pkg/sip/media_port.go`**: two new methods on `MediaPort`:
- `UpdateRemote`: atomically redirects the RTP destination.
- `RemoteAddr`: read accessor, used in tests.

**`pkg/sip/inbound.go`** : both re-INVITE paths now parse the SDP body and call `UpdateRemote` before responding 200 OK.

## Tests

`pkg/sip/media_port_test.go` — `TestMediaPortUpdateRemote` covers thehappy path, the zero-value no-op, and the unspecified-addr no-op.  `pkg/sip/signaling_test.go` — `TestReinvite` extended:

- `inbound/normal`: asserts `RemoteAddr()` changes after a re-INVITE.
- `outbound/normal`: same for the outbound path.
- `inbound/no_body`: asserts a body-less re-INVITE leaves `RemoteAddr()` unchanged.

---

### Unit tests
```bash
o test ./pkg/sip/... -run 'TestMediaPortUpdateRemote|TestReinvite/inbound/normal|TestReinvite/inbound/no_body|TestReinvite/outbound' -v  -count=1
```

### Integration tests
```bash
go test ./pkg/sip/... -count=1
```

---
  
#### Thought process summary
  
The root cause was a one-liner gap: the re-INVITE handler called AcceptAsKeepAlive (200 OK) but never forwarded the new c=/m= address to the RTP layer. The SDP body already contained the new addr+port as desc.Addr after ParseWith — nothing needed to be renegotiated, just the destination pointer swapped.

The tricky edge case was [RFC 3264 §8.4](https://www.rfc-editor.org/info/rfc3264/#section-8.4) call-hold, where c=0.0.0.0 signals hold and `netip.MustParseAddrPort("0.0.0.0:N").IsValid()` returns `true`. A plain `IsValid()` guard would have let hold re-INVITEs overwrite the real destination with the zero address. The `!addr.Addr().IsUnspecified()` check inside UpdateRemote blocks that.