### PR TITLE
Clearing cached destination before sending ACK or other request

### DIFF
--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -1014,21 +1015,33 @@ authLoop:
 		return nil, psrpc.NewErrorf(psrpc.Internal, "no tag in To header in INVITE response")
 	}
 
+	flushDestinationCache := false
 	if cont := resp.Contact(); cont != nil {
-		req.Recipient = cont.Address
-		if req.Recipient.Port == 0 {
-			req.Recipient.Port = 5060
+		newContact := cont.Address
+		if newContact.Port == 0 {
+			newContact.Port = 5060
 		}
+		oldRecipient := req.Recipient
+		if oldRecipient.Port == 0 {
+			oldRecipient.Port = 5060
+		}
+		flushDestinationCache = !strings.EqualFold(oldRecipient.Host, newContact.Host) || oldRecipient.Port != newContact.Port
+		req.Recipient = newContact
 	}
 
 	// We currently don't plumb the request back to caller to construct the ACK with.
 	// Thus, we need to modify the request to update any route sets.
 	for req.RemoveHeader("Route") {
+		flushDestinationCache = true
 	}
 	for _, hdr := range resp.GetHeaders("Record-Route") {
+		flushDestinationCache = true
 		req.PrependHeader(&sip.RouteHeader{Address: hdr.(*sip.RecordRouteHeader).Address})
 	}
 
+	if flushDestinationCache {
+		req.MessageData.SetDestination("") // Undo destination fixing
+	}
 	return c.inviteOk.Body(), nil
 }
 

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -127,6 +127,127 @@ func TestOutboundRouteHeaderWithRecordRoute(t *testing.T) {
 	cancel()
 }
 
+const (
+	testMinimalSDP = "v=0\r\no=- 0 0 IN IP4 127.0.0.1\r\ns=-\r\nc=IN IP4 127.0.0.1\r\nt=0 0\r\nm=audio 5004 RTP/AVP 0\r\na=rtpmap:0 PCMU/8000\r\n"
+	// Simulates sipgo caching a DNS-resolved transport target on the INVITE.
+	testInviteCachedDestination = "10.0.0.1:5060"
+	testInviteTargetHost        = "sip.example.com"
+)
+
+// waitOutboundINVITEAndACK drives CreateSIPParticipant until an INVITE is sent, fakes a 200 OK,
+// and returns the captured ACK. mutate is called after the INVITE is received and before the
+// 200 OK is delivered to the transaction.
+func waitOutboundINVITEAndACK(
+	t *testing.T,
+	participantReq *rpc.InternalCreateSIPParticipantRequest,
+	mutate func(tr *transactionRequest, resp *sip.Response),
+) (*transactionRequest, *sipRequest) {
+	t.Helper()
+
+	client := NewOutboundTestClient(t, TestClientConfig{})
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	go func() {
+		_, err := client.CreateSIPParticipant(ctx, participantReq)
+		if err != nil && ctx.Err() == nil {
+			t.Logf("CreateSIPParticipant error: %v", err)
+			t.Fail()
+		}
+	}()
+
+	var sipClient *testSIPClient
+	select {
+	case sipClient = <-createdClients:
+		t.Cleanup(func() { _ = sipClient.Close() })
+	case <-time.After(500 * time.Millisecond):
+		require.Fail(t, "expected test SIP client to be created")
+		return nil, nil
+	}
+
+	var tr *transactionRequest
+	select {
+	case tr = <-sipClient.transactions:
+		t.Cleanup(func() { tr.transaction.Terminate() })
+	case <-time.After(500 * time.Millisecond):
+		require.Fail(t, "expected INVITE transaction")
+		return nil, nil
+	}
+
+	require.Equal(t, sip.INVITE, tr.req.Method)
+
+	resp := sip.NewSDPResponseFromRequest(tr.req, []byte(testMinimalSDP))
+	require.NotNil(t, resp)
+	mutate(tr, resp)
+	require.NoError(t, tr.transaction.SendResponse(resp))
+
+	var ackReq *sipRequest
+	select {
+	case ackReq = <-sipClient.requests:
+	case <-time.After(500 * time.Millisecond):
+		require.Fail(t, "expected ACK request")
+		return tr, nil
+	}
+
+	require.Equal(t, sip.ACK, ackReq.req.Method)
+	return tr, ackReq
+}
+
+func TestOutboundACKDestinationAfterInviteResponse(t *testing.T) {
+	t.Run("changed contact flushes stale cached destination", func(t *testing.T) {
+		// Without the fix, NewAckRequest copies the INVITE's cached DNS destination
+		// (10.0.0.1:5060) even though the 200 OK Contact points elsewhere.
+		const (
+			contactHost = "10.0.0.99"
+			contactPort = 5080
+		)
+		contactURI := sip.Uri{Host: contactHost, Port: contactPort}
+
+		_, ackReq := waitOutboundINVITEAndACK(t, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
+			require.Equal(t, testInviteTargetHost, tr.req.Recipient.Host)
+			tr.req.SetDestination(testInviteCachedDestination)
+			resp.AppendHeader(&sip.ContactHeader{Address: contactURI})
+		})
+		require.NotNil(t, ackReq)
+
+		require.Equal(t, contactHost, ackReq.req.Recipient.Host)
+		require.Equal(t, contactPort, ackReq.req.Recipient.Port)
+		require.Equal(t, fmt.Sprintf("%s:%d", contactHost, contactPort), ackReq.req.Destination())
+		require.NotEqual(t, testInviteCachedDestination, ackReq.req.Destination())
+	})
+
+	t.Run("unchanged contact keeps cached destination", func(t *testing.T) {
+		contactURI := sip.Uri{Host: testInviteTargetHost, Port: 5060}
+
+		_, ackReq := waitOutboundINVITEAndACK(t, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
+			tr.req.SetDestination(testInviteCachedDestination)
+			resp.AppendHeader(&sip.ContactHeader{Address: contactURI})
+		})
+		require.NotNil(t, ackReq)
+
+		require.Equal(t, testInviteTargetHost, ackReq.req.Recipient.Host)
+		require.Equal(t, testInviteCachedDestination, ackReq.req.Destination())
+	})
+
+	t.Run("record route rebuild flushes stale cached destination", func(t *testing.T) {
+		// Route set changes must invalidate the cached destination even when Contact
+		// matches the original INVITE target.
+		proxyURI := sip.Uri{Host: "proxy.example.com", Port: 5060, UriParams: sip.HeaderParams{{"lr", ""}}}
+		contactURI := sip.Uri{Host: testInviteTargetHost, Port: 5060}
+
+		_, ackReq := waitOutboundINVITEAndACK(t, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
+			tr.req.SetDestination(testInviteCachedDestination)
+			resp.AppendHeader(&sip.ContactHeader{Address: contactURI})
+			resp.AppendHeader(&sip.RecordRouteHeader{Address: proxyURI})
+		})
+		require.NotNil(t, ackReq)
+
+		require.Equal(t, testInviteTargetHost, ackReq.req.Recipient.Host)
+		require.Equal(t, "proxy.example.com:5060", ackReq.req.Destination())
+		require.NotEqual(t, testInviteCachedDestination, ackReq.req.Destination())
+	})
+}
+
 func TestBuildOutboundHeaders(t *testing.T) {
 	newReq := func() *rpc.InternalCreateSIPParticipantRequest {
 		return &rpc.InternalCreateSIPParticipantRequest{}


### PR DESCRIPTION
Scenario:
- Inivite is created, no destination set.
- We send the invite on its way. It passes through sipgo.
- In sipgo, when sending the request out, [we calculate the destination](https://github.com/livekit/sipgo/blob/a5b4a38b6ceb491fbc36c2ef8db6e1bb3e35c32f/transport/layer.go#L271-L299).
- If it's an IP address, all is well.
- If it is a hostname, we resolve it, and fix the destination to that now-resolved IP using `req.SetDestination()`.

Then, when the 200 arrives:
- We [update c.invite.Recipient with contact](https://github.com/livekit/sip/blob/ab002ab5e66bdf2117292585a8198b5e4db30cd1/pkg/sip/outbound.go#L1017-L1032), but do not flush the destination stored in `req.MessageData.Destination()`.
- Construct an ACK to send it back.
- While constructing the ACK, we copy the updated recepient, but crucially we also `ackRequest.SetDestination(inviteRequest.Destination())` [here](https://github.com/livekit/sipgo/blob/a5b4a38b6ceb491fbc36c2ef8db6e1bb3e35c32f/sip/request.go#L112). `inviteRequest.Destination()` returns the fixed destination, and `ackRequest.SetDestination()` fixes it for the ACK response to the same thing. This [takes precedence](https://github.com/emiago/sipgo/blob/3dffa2770b218ace086a06d5b69bb093f413e5ec/sip/request.go#L207-L232) over `Route` headers, `Recepient`, and the `Contact` headr that might have been updated.