### PR TITLE
TEL-588: move no-ack to indeterminate

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1422,7 +1422,7 @@ func (c *inboundCall) closeWithTimeout(ctx context.Context, isError bool) {
 func (c *inboundCall) closeWithNoACK(ctx context.Context) {
 	c.close(ctx, EndCall{
 		Status: callNoACK,
-		Term:   stats.ServerError("no-ack"),
+		Term:   stats.Indeterminate("no-ack"),
 	})
 }
 


### PR DESCRIPTION
media timeout happens and there is no-ack received earlier, so most likely not server_error.