### PR TITLE
REL-29: downgrade error after invite to avoid retry

### DIFF
--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -26,6 +26,20 @@ type inviteFailure struct {
 	returnErr error
 }
 
+// afterInvite makes a server-side failure non-retryable once an INVITE has been
+// sent, so a fallback-capable SDK won't re-dial and place a duplicate call.
+// Other result classes already map to non-retryable codes; Term is unchanged.
+func (f inviteFailure) afterInvite() inviteFailure {
+	if f.Term.Result == stats.ResultServerError {
+		cause := f.returnErr
+		if cause == nil {
+			cause = errors.New(f.Term.Reason)
+		}
+		f.returnErr = psrpc.NewError(psrpc.FailedPrecondition, cause)
+	}
+	return f
+}
+
 // inviteClassifier lets an error describe its own verdict instead of
 // classifyInviteError carrying a switch over every variant. Source sites
 // wrap raw errors in these types so the classification lives next to where

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -165,6 +165,35 @@ func TestCarrierBlockFromResponse(t *testing.T) {
 	require.Nil(t, carrierBlockFromResponse(resp, st))
 }
 
+func TestInviteFailure_AfterInvite(t *testing.T) {
+	// Post-INVITE: server-side failures downgrade to a non-retryable code;
+	// client/upstream errors are left as-is. Term is always preserved.
+	cases := []struct {
+		name      string
+		in        inviteFailure
+		downgrade bool
+	}{
+		{"network-error", classifyInviteError(&net.OpError{Op: "write", Net: "tcp", Err: errors.New("broken pipe")}), true},
+		{"invite-failed", classifyInviteError(errors.New("ack write failed")), true},
+		{"client busy", classifyInviteError(&livekit.SIPStatus{Code: livekit.SIPStatusCode(486), Status: "busy"}), false},
+		{"upstream 503", classifyInviteError(&livekit.SIPStatus{Code: livekit.SIPStatusCode(503), Status: "unavailable"}), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := tc.in.returnErr
+			out := tc.in.afterInvite()
+			require.Equal(t, tc.in.Term, out.Term)
+			if !tc.downgrade {
+				require.Equal(t, before, out.returnErr)
+				return
+			}
+			code, _ := psrpc.GetErrorCode(out.returnErr)
+			require.Equal(t, psrpc.FailedPrecondition, code)
+			require.ErrorIs(t, out.returnErr, before)
+		})
+	}
+}
+
 func TestClassifyInviteError_ReturnErrWrap(t *testing.T) {
 	// Refined buckets that wrap returnErr with a specific psrpc code so the
 	// RPC boundary reflects the originating failure mode instead of an

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -420,6 +420,10 @@ func (c *outboundCall) connectSIP(ctx context.Context, tid traceid.ID) error {
 	if err := c.dialSIP(ctx, tid); err != nil {
 		c.log.Infow("SIP call failed", "error", err)
 		res := classifyInviteError(err)
+		if !c.sigTs.InviteTime.IsZero() {
+			// INVITE sent: a call may exist, so don't surface a retryable 5xx.
+			res = res.afterInvite()
+		}
 		c.close(ctx, res.EndCall)
 		return res.returnErr
 	}


### PR DESCRIPTION
to make sure retry won't happen after invite is sent