### PR TITLE
sip: classify Twilio carrier fraud blocks distinctly from callee decl…

### DIFF
--- a/pkg/sip/errors.go
+++ b/pkg/sip/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	"google.golang.org/grpc/codes"
@@ -98,6 +99,86 @@ func (e transactionTimeoutError) ClassifyInvite() inviteFailure {
 		},
 		returnErr: psrpc.NewError(psrpc.Canceled, e),
 	}
+}
+
+// twilioPermanentBlockCodes are Twilio X-Twilio-Error codes for calls a carrier
+// permanently blocks for fraud/regulatory reasons. Twilio surfaces these as a
+// generic SIP 603 Decline, which is indistinguishable from an ordinary callee
+// rejection, so we key off the proprietary error code instead. The distinct
+// classification lets callers suppress the destination rather than retrying it.
+//
+// This lives alongside the Twilio rate-limit handling in classifyInviteError.
+var twilioPermanentBlockCodes = map[int]struct{}{
+	32203: {}, // call blocked as potential fraud / regulatory block
+}
+
+// carrierBlockedError is an outbound INVITE that a carrier permanently rejected
+// (e.g. Twilio X-Twilio-Error 32203). It self-classifies so the failure reads
+// distinctly from a normal decline, and unwraps to the underlying SIPStatus so
+// the SIP code/text is still recorded on the call (CallStatusCode). Note it does
+// not overwrite SIPStatus.Status — the SIP reason phrase is preserved; the
+// provider block detail surfaces via the reported error and the SLI term.
+type carrierBlockedError struct {
+	status       *livekit.SIPStatus
+	provider     string // e.g. "twilio"
+	providerCode int    // e.g. 32203
+}
+
+var _ inviteClassifier = carrierBlockedError{}
+
+func (e carrierBlockedError) Error() string {
+	return fmt.Sprintf("carrier blocked call (%s error %d): %s", e.provider, e.providerCode, e.status.Error())
+}
+
+func (e carrierBlockedError) Unwrap() error { return e.status }
+
+func (e carrierBlockedError) ClassifyInvite() inviteFailure {
+	return inviteFailure{
+		EndCall: EndCall{
+			Status: callRejected,
+			// Distinct SLI bucket: a carrier fraud/regulatory block is a
+			// customer-side outcome, not upstream breakage.
+			Term: stats.ClientError("carrier-blocked"),
+			// No dedicated DisconnectReason enum exists yet; USER_REJECTED is the
+			// closest fit. The differentiator is the term and the reported error,
+			// which carry the provider block code for downstream consumers.
+			Reason: livekit.DisconnectReason_USER_REJECTED,
+			Report: e, // keep so the block (and provider code) is recorded
+		},
+		// Preserve the SIPStatus at the RPC boundary so ApplySIPStatus still maps
+		// the SIP code (e.g. 603) for the caller, matching other SIPStatus paths.
+		returnErr: e.status,
+	}
+}
+
+// carrierBlockFromResponse returns a carrierBlockedError if resp carries a
+// provider error code known to be a permanent carrier block, else nil. st is
+// the SIPStatus already built for resp and is retained on the returned error.
+func carrierBlockFromResponse(resp *sip.Response, st *livekit.SIPStatus) error {
+	if h := resp.GetHeader("X-Twilio-Error"); h != nil {
+		// Header format is "<code> <description>"; parse the leading code.
+		if code := parseLeadingProviderCode(h.Value()); code != 0 {
+			if _, ok := twilioPermanentBlockCodes[code]; ok {
+				return carrierBlockedError{status: st, provider: "twilio", providerCode: code}
+			}
+		}
+	}
+	return nil
+}
+
+// parseLeadingProviderCode extracts the leading integer code from a provider
+// error header value (e.g. "32203 Call blocked as potential fraud" -> 32203).
+// Returns 0 when the value does not start with a number.
+func parseLeadingProviderCode(v string) int {
+	fields := strings.Fields(v)
+	if len(fields) == 0 {
+		return 0
+	}
+	n, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return 0
+	}
+	return n
 }
 
 // classifyInviteError buckets an outbound INVITE error. Self-classifying

--- a/pkg/sip/errors_test.go
+++ b/pkg/sip/errors_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/livekit/media-sdk/sdp"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/psrpc"
+	"github.com/livekit/sipgo/sip"
 
 	"github.com/livekit/sip/pkg/stats"
 )
@@ -66,6 +67,10 @@ func TestClassifyInviteError(t *testing.T) {
 		{"600 Global Busy Everywhere", sipStatusErr(600), callRejected, stats.ClientError("global-decline-600"), livekit.DisconnectReason_USER_REJECTED, false},
 		{"603 Global Decline", sipStatusErr(603), callRejected, stats.ClientError("global-decline-603"), livekit.DisconnectReason_USER_REJECTED, false},
 
+		// Carrier permanent block (Twilio 32203) — distinct from a normal 603 decline
+		{"Twilio 32203 carrier block", carrierBlockedError{status: &livekit.SIPStatus{Code: 603, Status: "Decline"}, provider: "twilio", providerCode: 32203}, callRejected, stats.ClientError("carrier-blocked"), livekit.DisconnectReason_USER_REJECTED, true},
+		{"Twilio 32203 carrier block (wrapped)", fmt.Errorf("INVITE blocked by carrier: %w", carrierBlockedError{status: &livekit.SIPStatus{Code: 603, Status: "Decline"}, provider: "twilio", providerCode: 32203}), callRejected, stats.ClientError("carrier-blocked"), livekit.DisconnectReason_USER_REJECTED, true},
+
 		// SDP errors
 		{"SDP no common media", SDPError{Err: sdp.ErrNoCommonMedia}, callRejected, stats.ClientError("no-common-codec"), livekit.DisconnectReason_MEDIA_FAILURE, true},
 		{"SDP no common crypto", SDPError{Err: sdp.ErrNoCommonCrypto}, callRejected, stats.ClientError("encryption-required"), livekit.DisconnectReason_MEDIA_FAILURE, true},
@@ -114,6 +119,50 @@ func TestClassifyInviteError_SDPGRPCStatus(t *testing.T) {
 	code, ok := psrpc.GetErrorCode(res.returnErr)
 	require.True(t, ok)
 	require.Equal(t, psrpc.FailedPrecondition, code)
+}
+
+func TestParseLeadingProviderCode(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+	}{
+		{"32203 Call blocked as potential fraud", 32203},
+		{"32203", 32203},
+		{"  32203  ", 32203},
+		{"Decline", 0},
+		{"", 0},
+		{"blocked 32203", 0}, // code must lead
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, parseLeadingProviderCode(tc.in), tc.in)
+	}
+}
+
+func TestCarrierBlockFromResponse(t *testing.T) {
+	st := &livekit.SIPStatus{Code: 603, Status: "Decline"}
+
+	// No provider header -> not a carrier block.
+	resp := sip.NewResponse(603, "Decline")
+	require.Nil(t, carrierBlockFromResponse(resp, st))
+
+	// Twilio permanent-block code -> carrierBlockedError that classifies distinctly.
+	resp = sip.NewResponse(603, "Decline")
+	resp.AppendHeader(sip.NewHeader("X-Twilio-Error", "32203 Call blocked as potential fraud"))
+	err := carrierBlockFromResponse(resp, st)
+	require.NotNil(t, err)
+	res := classifyInviteError(fmt.Errorf("INVITE blocked by carrier: %w", err))
+	require.Equal(t, callRejected, res.Status)
+	require.Equal(t, stats.ClientError("carrier-blocked"), res.Term)
+	require.Equal(t, livekit.DisconnectReason_USER_REJECTED, res.Reason)
+	// The SIPStatus is preserved for CallStatusCode / RPC boundary mapping.
+	var sipStatus *livekit.SIPStatus
+	require.True(t, errors.As(err, &sipStatus))
+	require.Equal(t, livekit.SIPStatusCode(603), sipStatus.Code)
+
+	// A non-block Twilio error code -> not suppressed here.
+	resp = sip.NewResponse(486, "Busy Here")
+	resp.AppendHeader(sip.NewHeader("X-Twilio-Error", "13224 Invalid phone number"))
+	require.Nil(t, carrierBlockFromResponse(resp, st))
 }
 
 func TestClassifyInviteError_ReturnErrWrap(t *testing.T) {

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -950,25 +950,32 @@ authLoop:
 		case sip.StatusOK:
 			break authLoop
 		default:
-			return nil, fmt.Errorf("unexpected status from INVITE response: %w", &livekit.SIPStatus{
+			st := &livekit.SIPStatus{
 				Code:   livekit.SIPStatusCode(resp.StatusCode),
 				Status: resp.Reason,
-			})
+			}
+			if blocked := carrierBlockFromResponse(resp, st); blocked != nil {
+				return nil, fmt.Errorf("INVITE blocked by carrier: %w", blocked)
+			}
+			return nil, fmt.Errorf("unexpected status from INVITE response: %w", st)
 		case sip.StatusBadRequest,
 			sip.StatusNotFound,
 			sip.StatusTemporarilyUnavailable,
 			sip.StatusNotAcceptableHere,
 			sip.StatusBusyHere:
-			err := &livekit.SIPStatus{
+			st := &livekit.SIPStatus{
 				Code:   livekit.SIPStatusCode(resp.StatusCode),
 				Status: resp.Reason,
 			}
 			if body := resp.Body(); len(body) != 0 {
-				err.Status = string(body)
+				st.Status = string(body)
 			} else if s := resp.GetHeader("X-Twilio-Error"); s != nil {
-				err.Status = s.Value()
+				st.Status = s.Value()
 			}
-			return nil, fmt.Errorf("INVITE failed: %w", err)
+			if blocked := carrierBlockFromResponse(resp, st); blocked != nil {
+				return nil, fmt.Errorf("INVITE blocked by carrier: %w", blocked)
+			}
+			return nil, fmt.Errorf("INVITE failed: %w", st)
 		case sip.StatusUnauthorized:
 			authHeaderName = "WWW-Authenticate"
 			authHeaderRespName = "Authorization"


### PR DESCRIPTION
…ines

Twilio surfaces a permanent fraud/regulatory block (X-Twilio-Error 32203) as a generic SIP 603 Decline, which was indistinguishable from an ordinary callee rejection: both classified as USER_REJECTED / global-decline-603. Callers that want to suppress a permanently-blocked number couldn't tell the two apart on a failed CreateSIPParticipant.

Detect the X-Twilio-Error code on a non-2xx INVITE response and, for known permanent-block codes, wrap it in a self-classifying carrierBlockedError. It classifies as a distinct ClientError("carrier-blocked") SLI bucket and carries the provider code in the reported error, while preserving the underlying SIPStatus so CallStatusCode and the RPC boundary are unchanged. SIPStatus.Status (the SIP reason phrase) is not overwritten.

Lives alongside the existing Twilio rate-limit handling in classifyInviteError.