### PR TITLE
feat: optionally bind SIP signaling to a named interface (LIVEKIT_NODE_IP_IFACE)

### DIFF
--- a/cmd/livekit-sip/main.go
+++ b/cmd/livekit-sip/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"os/signal"
 	"syscall"
@@ -70,6 +71,17 @@ func runService(ctx context.Context, c *cli.Command) error {
 	if err != nil {
 		return err
 	}
+
+	// Resolve LIVEKIT_NODE_IP_IFACE (if set) into conf.ListenIP before the
+	// service starts. This mirrors the LiveKit media server behaviour: the env
+	// var names the network interface whose IPv4 address should be used for SIP
+	// signalling binding. It is useful in ECS/Fargate/Kubernetes where the
+	// container IP lives on a known interface (e.g. eth0) and must be bound
+	// explicitly rather than falling back to the 0.0.0.0 wildcard.
+	if err = applyNodeIPIface(conf); err != nil {
+		return err
+	}
+
 	log := logger.GetLogger()
 	if conf.JaegerURL != "" {
 		jaeger.Configure(ctx, conf.JaegerURL, conf.ServiceName)
@@ -122,6 +134,70 @@ func runService(ctx context.Context, c *cli.Command) error {
 	}()
 
 	return svc.Run()
+}
+
+// applyNodeIPIface reads LIVEKIT_NODE_IP_IFACE and, if set, resolves the first
+// IPv4 address of that interface into conf.ListenIP.
+//
+// The override is skipped when:
+//   - the env var is absent or empty, or
+//   - conf.ListenIP is already set to a specific (non-wildcard) address,
+//     meaning the operator made an explicit choice in the config file.
+func applyNodeIPIface(conf *config.Config) error {
+	iface := os.Getenv("LIVEKIT_NODE_IP_IFACE")
+	if iface == "" {
+		return nil
+	}
+
+	log := logger.GetLogger()
+
+	// Respect an explicit listen_ip that isn't the wildcard.
+	if conf.ListenIP != "" && conf.ListenIP != "0.0.0.0" {
+		log.Infow("LIVEKIT_NODE_IP_IFACE set but listen_ip already configured, skipping interface resolution",
+			"iface", iface,
+			"listen_ip", conf.ListenIP,
+		)
+		return nil
+	}
+
+	ip, err := ipv4FromIface(iface)
+	if err != nil {
+		return fmt.Errorf("LIVEKIT_NODE_IP_IFACE=%s: %w", iface, err)
+	}
+
+	log.Infow("resolved listen_ip from network interface", "iface", iface, "ip", ip)
+	conf.ListenIP = ip
+	return nil
+}
+
+// ipv4FromIface returns the first IPv4 address assigned to the named interface.
+func ipv4FromIface(name string) (string, error) {
+	ifc, err := net.InterfaceByName(name)
+	if err != nil {
+		return "", fmt.Errorf("interface %q not found: %w", name, err)
+	}
+	addrs, err := ifc.Addrs()
+	if err != nil {
+		return "", fmt.Errorf("cannot list addresses for %q: %w", name, err)
+	}
+	if ip, ok := firstIPv4(addrs); ok {
+		return ip, nil
+	}
+	return "", fmt.Errorf("no IPv4 address found on interface %q", name)
+}
+
+// firstIPv4 returns the first IPv4 address in addrs, if any.
+func firstIPv4(addrs []net.Addr) (string, bool) {
+	for _, addr := range addrs {
+		ipnet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		if ip4 := ipnet.IP.To4(); ip4 != nil {
+			return ip4.String(), true
+		}
+	}
+	return "", false
 }
 
 func getConfig(c *cli.Command, initialize bool) (*config.Config, error) {

--- a/cmd/livekit-sip/main_test.go
+++ b/cmd/livekit-sip/main_test.go
@@ -1,0 +1,96 @@
+// Copyright 2023 LiveKit, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"net"
+	"testing"
+
+	"github.com/livekit/sip/pkg/config"
+)
+
+func TestFirstIPv4(t *testing.T) {
+	cases := []struct {
+		name  string
+		addrs []net.Addr
+		want  string
+		ok    bool
+	}{
+		{
+			name:  "empty",
+			addrs: nil,
+			want:  "",
+			ok:    false,
+		},
+		{
+			name: "ipv6 only",
+			addrs: []net.Addr{
+				&net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)},
+			},
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "picks first ipv4",
+			addrs: []net.Addr{
+				&net.IPNet{IP: net.ParseIP("fe80::1"), Mask: net.CIDRMask(64, 128)},
+				&net.IPNet{IP: net.ParseIP("10.0.0.5"), Mask: net.CIDRMask(24, 32)},
+				&net.IPNet{IP: net.ParseIP("10.0.0.9"), Mask: net.CIDRMask(24, 32)},
+			},
+			want: "10.0.0.5",
+			ok:   true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, ok := firstIPv4(c.addrs)
+			if got != c.want || ok != c.ok {
+				t.Fatalf("firstIPv4() = (%q, %v), want (%q, %v)", got, ok, c.want, c.ok)
+			}
+		})
+	}
+}
+
+func TestApplyNodeIPIface(t *testing.T) {
+	t.Run("env unset is a no-op", func(t *testing.T) {
+		t.Setenv("LIVEKIT_NODE_IP_IFACE", "")
+		conf := &config.Config{ListenIP: ""}
+		if err := applyNodeIPIface(conf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conf.ListenIP != "" {
+			t.Fatalf("ListenIP = %q, want empty", conf.ListenIP)
+		}
+	})
+
+	t.Run("explicit listen_ip is preserved", func(t *testing.T) {
+		t.Setenv("LIVEKIT_NODE_IP_IFACE", "eth0")
+		conf := &config.Config{ListenIP: "10.1.2.3"}
+		if err := applyNodeIPIface(conf); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if conf.ListenIP != "10.1.2.3" {
+			t.Fatalf("ListenIP = %q, want 10.1.2.3", conf.ListenIP)
+		}
+	})
+
+	t.Run("unknown interface errors", func(t *testing.T) {
+		t.Setenv("LIVEKIT_NODE_IP_IFACE", "definitely-not-an-iface-xyz")
+		conf := &config.Config{ListenIP: ""}
+		if err := applyNodeIPIface(conf); err == nil {
+			t.Fatal("expected error for unknown interface, got nil")
+		}
+	})
+}


### PR DESCRIPTION
## What

Adds an optional `LIVEKIT_NODE_IP_IFACE` environment variable. When set, the first IPv4 address of the named network interface (e.g. `eth0`) is resolved at startup and used as the SIP signaling **bind** address (`listen_ip`).

It is a no-op when:
- the variable is unset/empty, or
- `listen_ip` is already set to a specific (non-wildcard) address in config — an explicit operator choice always wins.

## Why

This is about the **bind** address only, and is complementary to — not a replacement for — the existing advertised-IP options (`local_net`, `use_external_ip`, `nat_1_to_1_ip`).

On a **multi-homed host** (e.g. EC2 with multiple ENIs, bare metal, or K8s pods with several interfaces), binding SIP to `0.0.0.0` lets the kernel choose the source IP of outbound responses based on the routing table. That source IP can differ from the interface the request arrived on and from the IP advertised in `Contact`/`Via`/SDP. Many SIP peers and NATs drop responses whose source IP doesn't match where they sent the request, so signaling breaks.

Binding to the same interface you advertise keeps the response source IP consistent. `listen_ip` already lets you pin a **static** address, but in dynamically-scheduled environments (ECS/EC2/K8s) the address isn't known when the config is authored, whereas the **interface name** (`eth0`) is stable. Resolving by interface name at startup makes this ergonomic and mirrors the interface/`NODE_IP` resolution already used by the LiveKit media server, giving operators one consistent deployment pattern across LiveKit components.

## What this does **not** do

- It does not change the advertised `SignalingIP`/`MediaIP`. Those remain governed by `local_net` / `use_external_ip` / `nat_1_to_1_ip`.
- It is **not** required for single-ENI Fargate/`awsvpc` deployments, where a `0.0.0.0` bind plus `local_net` for the advertised IP is sufficient.

## How

- `applyNodeIPIface` runs right after config load in `runService`, resolving the interface into `conf.ListenIP` before the server starts.
- `ipv4FromIface` / `firstIPv4` do the lookup and pick the first IPv4 on the interface.

## Tests

Unit tests in `cmd/livekit-sip/main_test.go` cover the address-selection logic and the skip/override/error paths.

## Notes

The env-var name mirrors the LiveKit media server for cross-component consistency. Happy to rename, or to expose this as a `listen_iface` config field instead of an env var, if maintainers prefer.
