### PR TITLE
do not ack bye

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -2141,7 +2141,7 @@ func (c *sipInbound) sendBye(ctx context.Context, headers map[string]string) {
 	c.setCSeq(r)
 	c.swapSrcDst(r)
 	c.drop()
-	sendAndACK(ctx, c, r)
+	sendBye(ctx, c.log, c, r)
 }
 
 func (c *sipInbound) sendStatus(ctx context.Context, result Result, headers map[string]string) {

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -1173,7 +1173,7 @@ func (c *sipOutbound) sendBye(ctx context.Context, headers map[string]string) {
 	}
 	c.setCSeq(r)
 	c.drop()
-	sendAndACK(ctx, c, r)
+	sendBye(ctx, c.log, c, r)
 }
 
 func (c *sipOutbound) sendCancel(ctx context.Context, headers map[string]string) {

--- a/pkg/sip/protocol.go
+++ b/pkg/sip/protocol.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/livekit/protocol/livekit"
+	"github.com/livekit/protocol/logger"
 	"github.com/livekit/psrpc"
 	"github.com/livekit/sip/pkg/stats"
 	"github.com/livekit/sipgo/sip"
@@ -225,18 +226,17 @@ func getContactURI(c *config.Config, ip netip.Addr, t Transport) URI {
 	}
 }
 
-func sendAndACK(ctx context.Context, c Signaling, req *sip.Request) {
+// sendBye sends a BYE and waits for its final response. BYE is a non-INVITE
+// transaction (RFC 3261 §17.1.2): the response ends it, no ACK is sent.
+func sendBye(ctx context.Context, log logger.Logger, c Signaling, req *sip.Request) {
 	tx, err := c.Transaction(req)
 	if err != nil {
+		log.Infow("cannot send BYE", "error", err)
 		return
 	}
 	defer tx.Terminate()
-	r, err := sipResponse(ctx, tx, nil, nil)
-	if err != nil {
-		return
-	}
-	if r.StatusCode == 200 {
-		_ = c.WriteRequest(sip.NewAckRequest(req, r, nil))
+	if _, err := sipResponse(ctx, tx, nil, nil); err != nil {
+		log.Infow("no response to BYE", "error", err)
 	}
 }
 

--- a/test/integration/docker_mac_test.go
+++ b/test/integration/docker_mac_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/ory/dockertest/v3"
 )
 
-const dockerBridgeIP = "172.17.0.1"
-
 var Docker *dockertest.Pool
 
 func TestMain(m *testing.M) {

--- a/test/integration/docker_test.go
+++ b/test/integration/docker_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/ory/dockertest/v3"
 )
 
-const dockerBridgeIP = "172.17.0.1"
-
 var Docker *dockertest.Pool
 
 func TestMain(m *testing.M) {

--- a/test/integration/livekit_test.go
+++ b/test/integration/livekit_test.go
@@ -3,7 +3,6 @@ package integration
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -22,7 +21,7 @@ var debugLKServer = os.Getenv("DEBUG_LK_SERVER") != ""
 
 var redisLast uint32
 
-func runRedis(t testing.TB) *redis.RedisConfig {
+func runRedis(t testing.TB, network *dockertest.Network) (*redis.RedisConfig, string) {
 	name := fmt.Sprintf("siptest-redis-%d", atomic.AddUint32(&redisLast, 1))
 	c, ok := Docker.ContainerByName(name)
 	if ok {
@@ -33,6 +32,7 @@ func runRedis(t testing.TB) *redis.RedisConfig {
 		&dockertest.RunOptions{
 			Name:       name,
 			Repository: "redis", Tag: "latest",
+			Networks: []*dockertest.Network{network},
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -44,7 +44,8 @@ func runRedis(t testing.TB) *redis.RedisConfig {
 	waitTCPPort(t, addr)
 
 	t.Log("Redis running on", addr)
-	return &redis.RedisConfig{Address: addr}
+	// addr: host-published (SIP service); name:6379: in-network (LiveKit container).
+	return &redis.RedisConfig{Address: addr}, name
 }
 
 type LiveKit struct {
@@ -55,14 +56,21 @@ type LiveKit struct {
 var livekitLast uint32
 
 func runLiveKit(t testing.TB) *LiveKit {
-	redis := runRedis(t)
+	id := atomic.AddUint32(&livekitLast, 1)
 
-	_, port, err := net.SplitHostPort(redis.Address)
+	// Shared network so LiveKit reaches Redis by name, avoiding a
+	// container->host round-trip that some CI runners block.
+	network, err := Docker.CreateNetwork(fmt.Sprintf("siptest-net-%d", id))
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() {
+		_ = network.Close()
+	})
 
-	name := fmt.Sprintf("siptest-livekit-%d", atomic.AddUint32(&livekitLast, 1))
+	redis, redisName := runRedis(t, network)
+
+	name := fmt.Sprintf("siptest-livekit-%d", id)
 	c, ok := Docker.ContainerByName(name)
 	if ok {
 		t.Log("Livekit-server container already exists - stopping and removing", name)
@@ -74,12 +82,11 @@ func runLiveKit(t testing.TB) *LiveKit {
 			Repository: "livekit/livekit-server", Tag: "master",
 			Cmd: []string{
 				"--dev",
-				// TODO: We use Docker bridge IP here instead of the host IP.
-				//       Maybe run on the host network instead? We might need it for RTP anyway.
-				"--redis-host", dockerBridgeIP + ":" + port,
+				"--redis-host", redisName + ":6379",
 				"--bind", "0.0.0.0",
 			},
 			ExposedPorts: []string{"7880/tcp"},
+			Networks:     []*dockertest.Network{network},
 		})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
We should not send ACK to BYE per spec. Combined with some non-compliant implementation on the customer's SBC, this can lead to CSeq increase incorrectly.