### PR TITLE
decouple transfer timeout from ringing_timeout

### DIFF
--- a/pkg/sip/participant.go
+++ b/pkg/sip/participant.go
@@ -69,6 +69,9 @@ const (
 	//
 	// For outbound, this sets a timeout for the other end to pick up the call.
 	defaultRingingTimeout = 3 * time.Minute
+	// defaultTransferTimeout bounds how long a REFER-based transfer is allowed to
+	// take. It is independent of the call's ringing timeout.
+	defaultTransferTimeout = 120 * time.Second
 )
 
 const (

--- a/pkg/sip/service.go
+++ b/pkg/sip/service.go
@@ -357,13 +357,10 @@ func (s *Service) transferSIPParticipant(ctx context.Context, req *rpc.InternalT
 		s.log.Debugw("repeated request for call transfer", "callID", req.SipCallId, "transferTo", req.TransferTo)
 		// TODO: Maybe just bump the psrpc timeout? It gets auto retried anyway internally.
 	} else {
-		// Initial transfer request for this call
-		timeout := req.RingingTimeout.AsDuration()
-		if timeout <= 0 {
-			// RingingTimeout is either specified by caller, or defaults to 30 seconds.
-			// This code should be pretty much unreachable.
-			timeout = 120 * time.Second
-		}
+		// Initial transfer request for this call.
+		// RingingTimeout on the request is intentionally ignored: it governs how long
+		// a call waits to connect/ring, which is unrelated to bounding a REFER transfer.
+		timeout := defaultTransferTimeout
 
 		go func() {
 			ctx, cdone := context.WithTimeout(context.WithoutCancel(ctx), timeout)

--- a/pkg/sip/signaling_test.go
+++ b/pkg/sip/signaling_test.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/livekit/media-sdk/sdp"
 	"github.com/livekit/mediatransportutil/pkg/rtcconfig"
@@ -861,9 +860,6 @@ func TestTransfer(t *testing.T) {
 				TransferTo:   to,
 				Headers:      headers,
 				PlayDialtone: dialtone,
-			}
-			if deadline, ok := ctx.Deadline(); ok {
-				transferReq.RingingTimeout = durationpb.New(time.Until(deadline) + (5 * time.Millisecond))
 			}
 			_, err := st.Service.TransferSIPParticipant(ctx, transferReq)
 			if err != nil {


### PR DESCRIPTION
The transfer timeout was derived from the request's RingingTimeout, which governs how long a call waits to connect/ring and is unrelated to bounding a REFER-based transfer. Introduce a dedicated defaultTransferTimeout (120s) and ignore RingingTimeout for transfers.