### PR TITLE
fix: log term reason

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1349,7 +1349,7 @@ func (c *inboundCall) close(ctx context.Context, end EndCall) {
 			Status: "Request Terminated",
 		}
 	}
-	log := c.log().WithValues("status", result.Code, "result", string(end.Term.Result), "reason", end.Reason)
+	log := c.log().WithValues("status", result.Code, "result", string(end.Term.Result), "reason", end.Term.Reason)
 	defer func() {
 		c.stats.Update()
 		c.printStats(log)


### PR DESCRIPTION
Log Term.Reason, not EndCall.Reason: no inbound close path populates the latter, so it always logged UNKNOWN_REASON. Term.Reason is the descriptive string ("media-timeout", "no-ack", "bye-q850-16", ...) already reported to OnSessionEnd, and matches what outbound logs.