### PR TITLE
Configure SIP default codec set instead of a default one for SDK.

### DIFF
--- a/pkg/sip/media_codecs.go
+++ b/pkg/sip/media_codecs.go
@@ -43,6 +43,10 @@ func init() {
 	})
 }
 
+func DefaultCodecs() *msdk.CodecSet {
+	return defaultCodecs
+}
+
 func newMediaConfig(m *livekit.SIPMediaConfig, defaultTimeout time.Duration) (*sipMediaConfig, error) {
 	enc, err := sdpEncryption(m.Encryption)
 	if err != nil {

--- a/pkg/sip/service.go
+++ b/pkg/sip/service.go
@@ -35,7 +35,6 @@ import (
 
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	msdk "github.com/livekit/media-sdk"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
 	"github.com/livekit/protocol/rpc"
@@ -215,7 +214,7 @@ func (s *Service) Start() error {
 			s.log.Warnw("codec disabled", nil, "name", name)
 		}
 	}
-	msdk.CodecsSetEnabled(s.conf.Codecs)
+	DefaultCodecs().SetEnabledMap(s.conf.Codecs)
 
 	if err := s.mon.Start(s.conf); err != nil {
 		return err


### PR DESCRIPTION
SIP server was incorrectly setting the configured default codecs. Configuration code path used a legacy API instead of a codec set that SIP defines explicitly in it's own package.