### PR TITLE
Fix bug where max call duration was not being respected for outbound calls.

### DIFF
--- a/pkg/sip/client.go
+++ b/pkg/sip/client.go
@@ -432,6 +432,7 @@ func (c *Client) createSIPParticipant(ctx context.Context, req *rpc.InternalCrea
 		mediaConfig:     mconf,
 	}
 	log.Infow("Creating SIP participant")
+	deadline := time.Now().Add(sipConf.maxCallDuration)
 	call, err := c.newCall(ctx, tid, c.conf, log, LocalTag(req.SipCallId), roomConf, sipConf, state, req.ProjectId)
 	if err != nil {
 		return nil, err
@@ -448,10 +449,19 @@ func (c *Client) createSIPParticipant(ctx context.Context, req *rpc.InternalCrea
 		call.DialAsync(ctx)
 		return info, nil
 	}
-	if err := call.Dial(ctx); err != nil {
+
+	dialCtx, dialCancel := context.WithDeadline(ctx, deadline)
+	defer dialCancel()
+
+	if err := call.Dial(dialCtx); err != nil {
 		return nil, err
 	}
-	go call.WaitClose(context.WithoutCancel(ctx))
+
+	// Detach this context from the context of the RPC so that the RPC returning
+	// doesn't cause the call to end prematurely.
+	detachedCtx, detatchedCancel := context.WithDeadline(ctx, deadline)
+	defer detatchedCancel()
+	go call.WaitClose(detachedCtx)
 	return info, nil
 }
 

--- a/pkg/sip/client.go
+++ b/pkg/sip/client.go
@@ -458,11 +458,11 @@ func (c *Client) createSIPParticipant(ctx context.Context, req *rpc.InternalCrea
 		return nil, err
 	}
 
-	// Detach this context from the context of the RPC so that the RPC returning
-	// doesn't cause the call to end prematurely.
+	// Detach this context from that of the RPC so that when the RPC returns,
+	// the call doesn't end prematurely.
 	go func() {
-		detachedCtx, detatchedCancel := context.WithDeadline(context.WithoutCancel(ctx), deadline)
-		defer detatchedCancel()
+		detachedCtx, detachedCancel := context.WithDeadline(context.WithoutCancel(ctx), deadline)
+		defer detachedCancel()
 		call.WaitClose(detachedCtx)
 	}()
 	return info, nil

--- a/pkg/sip/client.go
+++ b/pkg/sip/client.go
@@ -432,11 +432,12 @@ func (c *Client) createSIPParticipant(ctx context.Context, req *rpc.InternalCrea
 		mediaConfig:     mconf,
 	}
 	log.Infow("Creating SIP participant")
-	deadline := time.Now().Add(sipConf.maxCallDuration)
 	call, err := c.newCall(ctx, tid, c.conf, log, LocalTag(req.SipCallId), roomConf, sipConf, state, req.ProjectId)
 	if err != nil {
 		return nil, err
 	}
+	deadline := time.Now().Add(call.sipConf.maxCallDuration)
+
 	p := call.Participant()
 	// Start actual SIP call async.
 

--- a/pkg/sip/client.go
+++ b/pkg/sip/client.go
@@ -459,9 +459,11 @@ func (c *Client) createSIPParticipant(ctx context.Context, req *rpc.InternalCrea
 
 	// Detach this context from the context of the RPC so that the RPC returning
 	// doesn't cause the call to end prematurely.
-	detachedCtx, detatchedCancel := context.WithDeadline(ctx, deadline)
-	defer detatchedCancel()
-	go call.WaitClose(detachedCtx)
+	go func() {
+		detachedCtx, detatchedCancel := context.WithDeadline(context.WithoutCancel(ctx), deadline)
+		defer detatchedCancel()
+		call.WaitClose(detachedCtx)
+	}()
 	return info, nil
 }
 

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -241,8 +241,11 @@ func (c *outboundCall) WaitClose(ctx context.Context) error {
 	return c.waitClose(ctx, c.tid)
 }
 func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
-	ctx = context.WithoutCancel(ctx)
 	defer c.ensureClosed(ctx)
+
+	ctx = context.WithoutCancel(ctx)
+	ctx, cancel := context.WithTimeout(ctx, c.sipConf.maxCallDuration)
+	defer cancel()
 
 	ticker := time.NewTicker(stateUpdateTick)
 	defer ticker.Stop()
@@ -270,6 +273,13 @@ func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
 			err := psrpc.NewErrorf(psrpc.DeadlineExceeded, "media timeout")
 			c.setErrStatus(ctx, err)
 			return err
+		case <-ctx.Done():
+			c.CloseWith(ctx, EndCall{
+				Status: CallHangup,
+				Term:   stats.Success("max-call-duration"),
+				Reason: livekit.DisconnectReason_CLIENT_INITIATED,
+			})
+			return nil
 		case <-c.Closed():
 			return nil
 		}

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -380,7 +380,9 @@ func (c *outboundCall) close(ctx context.Context, end EndCall) bool {
 		// attributes_to_headers mapping in the setHeaders callback.
 		// See: https://github.com/livekit/sip/issues/404
 		c.stopSIP(ctx, end.Term, end.Headers)
-		c.media.Close()
+		if c.media != nil {
+			c.media.Close()
+		}
 
 		if r := c.lkRoom; r != nil {
 			_ = r.CloseOutput()
@@ -551,6 +553,9 @@ func sipResponse(ctx context.Context, tx sip.ClientTransaction, stop <-chan stru
 		case <-tx.Done():
 			return nil, psrpc.NewError(psrpc.Canceled, transactionTimeoutError{responses: cnt})
 		case res := <-tx.Responses():
+			if res == nil {
+				return nil, psrpc.NewError(psrpc.Canceled, transactionTimeoutError{responses: cnt})
+			}
 			status := res.StatusCode
 			if setState != nil {
 				setState(res.StatusCode, res.Headers())

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -241,9 +241,9 @@ func (c *outboundCall) WaitClose(ctx context.Context) error {
 	return c.waitClose(ctx, c.tid)
 }
 func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
+	ctx = context.WithoutCancel(ctx)
 	defer c.ensureClosed(ctx)
 
-	ctx = context.WithoutCancel(ctx)
 	ctx, cancel := context.WithTimeout(ctx, c.sipConf.maxCallDuration)
 	defer cancel()
 

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -276,7 +276,7 @@ func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
 		case <-ctx.Done():
 			c.CloseWith(ctx, EndCall{
 				Status: CallHangup,
-				Term:   stats.Success("max-call-duration"),
+				Term:   stats.Success("hangup"),
 				Reason: livekit.DisconnectReason_CLIENT_INITIATED,
 			})
 			return nil

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -211,8 +211,6 @@ func (c *outboundCall) setErrStatus(ctx context.Context, err error) {
 func (c *outboundCall) Dial(ctx context.Context) error {
 	ctx, span := Tracer.Start(ctx, "sip.outbound.Dial")
 	defer span.End()
-	ctx, cancel := context.WithTimeout(ctx, c.sipConf.maxCallDuration)
-	defer cancel()
 	c.mon.CallStart()
 	defer c.mon.CallEnd()
 
@@ -241,11 +239,7 @@ func (c *outboundCall) WaitClose(ctx context.Context) error {
 	return c.waitClose(ctx, c.tid)
 }
 func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
-	ctx = context.WithoutCancel(ctx)
 	defer c.ensureClosed(ctx)
-
-	ctx, cancel := context.WithTimeout(ctx, c.sipConf.maxCallDuration)
-	defer cancel()
 
 	ticker := time.NewTicker(stateUpdateTick)
 	defer ticker.Stop()
@@ -289,8 +283,10 @@ func (c *outboundCall) waitClose(ctx context.Context, tid traceid.ID) error {
 func (c *outboundCall) DialAsync(ctx context.Context) {
 	ctx, span := Tracer.Start(ctx, "sip.outbound.DialAsync")
 	defer span.End()
-	ctx = context.WithoutCancel(ctx)
+
 	go func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), c.sipConf.maxCallDuration)
+		defer cancel()
 		if err := c.Dial(ctx); err != nil {
 			return
 		}

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -387,7 +387,7 @@ func TestOutboundMaxCallDuration(t *testing.T) {
 
 	select {
 	case end := <-ended:
-		require.Equal(t, "max-call-duration", end.reason)
+		require.Equal(t, "hangup", end.reason)
 		require.Equal(t, livekit.DisconnectReason_CLIENT_INITIATED, end.info.DisconnectReason)
 	case <-time.After(2 * time.Second):
 		require.Fail(t, "expected call to have already ended")

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -170,7 +170,6 @@ func waitOutboundINVITEAndACK(
 	participantReq *rpc.InternalCreateSIPParticipantRequest,
 	mutate func(tr *transactionRequest, resp *sip.Response),
 ) (*testSIPClient, *transactionRequest, *sipRequest) {
-	t.Helper()
 
 	client := NewOutboundTestClient(t, clientCfg)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/rpc"
@@ -139,12 +140,13 @@ const (
 // 200 OK is delivered to the transaction.
 func waitOutboundINVITEAndACK(
 	t *testing.T,
+	clientCfg TestClientConfig,
 	participantReq *rpc.InternalCreateSIPParticipantRequest,
 	mutate func(tr *transactionRequest, resp *sip.Response),
-) (*transactionRequest, *sipRequest) {
+) (*testSIPClient, *transactionRequest, *sipRequest) {
 	t.Helper()
 
-	client := NewOutboundTestClient(t, TestClientConfig{})
+	client := NewOutboundTestClient(t, clientCfg)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
@@ -162,7 +164,7 @@ func waitOutboundINVITEAndACK(
 		t.Cleanup(func() { _ = sipClient.Close() })
 	case <-time.After(500 * time.Millisecond):
 		require.Fail(t, "expected test SIP client to be created")
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	var tr *transactionRequest
@@ -171,7 +173,7 @@ func waitOutboundINVITEAndACK(
 		t.Cleanup(func() { tr.transaction.Terminate() })
 	case <-time.After(500 * time.Millisecond):
 		require.Fail(t, "expected INVITE transaction")
-		return nil, nil
+		return sipClient, nil, nil
 	}
 
 	require.Equal(t, sip.INVITE, tr.req.Method)
@@ -186,11 +188,31 @@ func waitOutboundINVITEAndACK(
 	case ackReq = <-sipClient.requests:
 	case <-time.After(500 * time.Millisecond):
 		require.Fail(t, "expected ACK request")
-		return tr, nil
+		return sipClient, tr, nil
 	}
 
 	require.Equal(t, sip.ACK, ackReq.req.Method)
-	return tr, ackReq
+	return sipClient, tr, ackReq
+}
+
+// answerBYE waits for the call to send a BYE and responds 200 OK.
+// If we don't explicitly answer the BYE, then a test might hang, as sipOutbound
+// expects a response before closing the call.
+func answerBYE(t *testing.T, sipClient *testSIPClient, timeout time.Duration) {
+	t.Helper()
+
+	var byeTx *transactionRequest
+	select {
+	case byeTx = <-sipClient.transactions:
+	case <-time.After(timeout):
+		require.Fail(t, "expected BYE transaction")
+		return
+	}
+	require.Equal(t, sip.BYE, byeTx.req.Method)
+
+	resp := sip.NewResponseFromRequest(byeTx.req, 200, "OK", nil)
+	err := byeTx.transaction.SendResponse(resp)
+	require.NoError(t, err)
 }
 
 func TestOutboundACKDestinationAfterInviteResponse(t *testing.T) {
@@ -203,7 +225,7 @@ func TestOutboundACKDestinationAfterInviteResponse(t *testing.T) {
 		)
 		contactURI := sip.Uri{Host: contactHost, Port: contactPort}
 
-		_, ackReq := waitOutboundINVITEAndACK(t, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
+		_, _, ackReq := waitOutboundINVITEAndACK(t, TestClientConfig{}, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
 			require.Equal(t, testInviteTargetHost, tr.req.Recipient.Host)
 			tr.req.SetDestination(testInviteCachedDestination)
 			resp.AppendHeader(&sip.ContactHeader{Address: contactURI})
@@ -219,7 +241,7 @@ func TestOutboundACKDestinationAfterInviteResponse(t *testing.T) {
 	t.Run("unchanged contact keeps cached destination", func(t *testing.T) {
 		contactURI := sip.Uri{Host: testInviteTargetHost, Port: 5060}
 
-		_, ackReq := waitOutboundINVITEAndACK(t, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
+		_, _, ackReq := waitOutboundINVITEAndACK(t, TestClientConfig{}, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
 			tr.req.SetDestination(testInviteCachedDestination)
 			resp.AppendHeader(&sip.ContactHeader{Address: contactURI})
 		})
@@ -235,7 +257,7 @@ func TestOutboundACKDestinationAfterInviteResponse(t *testing.T) {
 		proxyURI := sip.Uri{Host: "proxy.example.com", Port: 5060, UriParams: sip.HeaderParams{{"lr", ""}}}
 		contactURI := sip.Uri{Host: testInviteTargetHost, Port: 5060}
 
-		_, ackReq := waitOutboundINVITEAndACK(t, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
+		_, _, ackReq := waitOutboundINVITEAndACK(t, TestClientConfig{}, MinimalCreateSIPParticipantRequest(), func(tr *transactionRequest, resp *sip.Response) {
 			tr.req.SetDestination(testInviteCachedDestination)
 			resp.AppendHeader(&sip.ContactHeader{Address: contactURI})
 			resp.AppendHeader(&sip.RecordRouteHeader{Address: proxyURI})
@@ -246,6 +268,37 @@ func TestOutboundACKDestinationAfterInviteResponse(t *testing.T) {
 		require.Equal(t, "proxy.example.com:5060", ackReq.req.Destination())
 		require.NotEqual(t, testInviteCachedDestination, ackReq.req.Destination())
 	})
+}
+
+func TestOutboundMaxCallDuration(t *testing.T) {
+	type sessionEnd struct {
+		reason string
+		info   *livekit.SIPCallInfo
+	}
+	ended := make(chan sessionEnd, 1)
+
+	clientCfg := TestClientConfig{Handler: &TestHandler{
+		OnSessionEndFunc: func(_ context.Context, _ *CallIdentifier, state *CallState, reason string) {
+			ended <- sessionEnd{reason: reason, info: state.Info()}
+		},
+	}}
+
+	req := MinimalCreateSIPParticipantRequest()
+	req.MaxCallDuration = durationpb.New(100 * time.Millisecond)
+	sipClient, _, _ := waitOutboundINVITEAndACK(t, clientCfg, req,
+		func(tr *transactionRequest, resp *sip.Response) {})
+	require.NotNil(t, sipClient)
+
+	// The call is answered; maxCallDuration should now hang it up on its own.
+	answerBYE(t, sipClient, 2*time.Second)
+
+	select {
+	case end := <-ended:
+		require.Equal(t, "max-call-duration", end.reason)
+		require.Equal(t, livekit.DisconnectReason_CLIENT_INITIATED, end.info.DisconnectReason)
+	case <-time.After(2 * time.Second):
+		require.Fail(t, "expected call to end")
+	}
 }
 
 func TestBuildOutboundHeaders(t *testing.T) {

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -289,7 +289,6 @@ func TestOutboundMaxCallDuration(t *testing.T) {
 		func(tr *transactionRequest, resp *sip.Response) {})
 	require.NotNil(t, sipClient)
 
-	// The call is answered; maxCallDuration should now hang it up on its own.
 	answerBYE(t, sipClient, 2*time.Second)
 
 	select {

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -365,33 +365,56 @@ func TestWatchCancelledInvite(t *testing.T) {
 }
 
 func TestOutboundMaxCallDuration(t *testing.T) {
+
+	type testCase struct {
+		name              string
+		waitUntilAnswered bool
+	}
 	type sessionEnd struct {
 		reason string
 		info   *livekit.SIPCallInfo
 	}
-	ended := make(chan sessionEnd, 1)
 
-	clientCfg := TestClientConfig{Handler: &TestHandler{
-		OnSessionEndFunc: func(_ context.Context, _ *CallIdentifier, state *CallState, reason string) {
-			ended <- sessionEnd{reason: reason, info: state.Info()}
+	testCases := []testCase{
+		{
+			name:              "dial_async",
+			waitUntilAnswered: false,
 		},
-	}}
-
-	req := MinimalCreateSIPParticipantRequest()
-	req.MaxCallDuration = durationpb.New(100 * time.Millisecond)
-	sipClient, _, _ := waitOutboundINVITEAndACK(t, clientCfg, req,
-		func(tr *transactionRequest, resp *sip.Response) {})
-	require.NotNil(t, sipClient)
-
-	answerBYE(t, sipClient, 2*time.Second)
-
-	select {
-	case end := <-ended:
-		require.Equal(t, "hangup", end.reason)
-		require.Equal(t, livekit.DisconnectReason_CLIENT_INITIATED, end.info.DisconnectReason)
-	case <-time.After(2 * time.Second):
-		require.Fail(t, "expected call to have already ended")
+		{
+			name:              "dial_sync",
+			waitUntilAnswered: true,
+		},
 	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			ended := make(chan sessionEnd, 1)
+
+			clientCfg := TestClientConfig{Handler: &TestHandler{
+				OnSessionEndFunc: func(_ context.Context, _ *CallIdentifier, state *CallState, reason string) {
+					ended <- sessionEnd{reason: reason, info: state.Info()}
+				},
+			}}
+
+			req := MinimalCreateSIPParticipantRequest()
+			req.WaitUntilAnswered = testCase.waitUntilAnswered
+			req.MaxCallDuration = durationpb.New(100 * time.Millisecond)
+			sipClient, _, _ := waitOutboundINVITEAndACK(t, clientCfg, req,
+				func(tr *transactionRequest, resp *sip.Response) {})
+			require.NotNil(t, sipClient)
+
+			answerBYE(t, sipClient, 2*time.Second)
+
+			select {
+			case end := <-ended:
+				require.Equal(t, "hangup", end.reason)
+				require.Equal(t, livekit.DisconnectReason_CLIENT_INITIATED, end.info.DisconnectReason)
+			case <-time.After(2 * time.Second):
+				require.Fail(t, "expected call to have already ended")
+			}
+		})
+	}
+
 }
 
 func TestBuildOutboundHeaders(t *testing.T) {

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -365,6 +365,8 @@ func TestWatchCancelledInvite(t *testing.T) {
 }
 
 func TestOutboundMaxCallDuration(t *testing.T) {
+	const maxCallDuration = time.Second
+	const waitSlack = time.Second
 
 	type testCase struct {
 		name              string
@@ -398,18 +400,18 @@ func TestOutboundMaxCallDuration(t *testing.T) {
 
 			req := MinimalCreateSIPParticipantRequest()
 			req.WaitUntilAnswered = testCase.waitUntilAnswered
-			req.MaxCallDuration = durationpb.New(100 * time.Millisecond)
+			req.MaxCallDuration = durationpb.New(maxCallDuration)
 			sipClient, _, _ := waitOutboundINVITEAndACK(t, clientCfg, req,
 				func(tr *transactionRequest, resp *sip.Response) {})
 			require.NotNil(t, sipClient)
 
-			answerBYE(t, sipClient, 2*time.Second)
+			answerBYE(t, sipClient, maxCallDuration+waitSlack)
 
 			select {
 			case end := <-ended:
 				require.Equal(t, "hangup", end.reason)
 				require.Equal(t, livekit.DisconnectReason_CLIENT_INITIATED, end.info.DisconnectReason)
-			case <-time.After(2 * time.Second):
+			case <-time.After(maxCallDuration + waitSlack):
 				require.Fail(t, "expected call to have already ended")
 			}
 		})

--- a/pkg/sip/outbound_test.go
+++ b/pkg/sip/outbound_test.go
@@ -296,7 +296,7 @@ func TestOutboundMaxCallDuration(t *testing.T) {
 		require.Equal(t, "max-call-duration", end.reason)
 		require.Equal(t, livekit.DisconnectReason_CLIENT_INITIATED, end.info.DisconnectReason)
 	case <-time.After(2 * time.Second):
-		require.Fail(t, "expected call to end")
+		require.Fail(t, "expected call to have already ended")
 	}
 }
 

--- a/pkg/sip/outbound_utilities_test.go
+++ b/pkg/sip/outbound_utilities_test.go
@@ -478,9 +478,11 @@ type TestClientConfig struct {
 	GetIOClient  GetStateHandler  // MockIOInfoClient if nil
 	GetSipClient GetSipClientFunc // NewTestClientFunc if nil
 	GetRoom      GetRoomFunc      // newTestRoom if nil
+	Handler      Handler          // empty TestHandler if nil
 }
 
 func NewOutboundTestClient(t testing.TB, cfg TestClientConfig) *Client {
+	t.Helper()
 	if cfg.Region == "" {
 		cfg.Region = "test"
 	}
@@ -537,8 +539,12 @@ func NewOutboundTestClient(t testing.TB, cfg TestClientConfig) *Client {
 	if cfg.GetRoom == nil {
 		cfg.GetRoom = newTestRoomConfig(nil)
 	}
+	if cfg.Handler == nil {
+		cfg.Handler = &TestHandler{}
+	}
+
 	client := NewClient(cfg.Region, cfg.Config, log, cfg.Monitor, cfg.GetIOClient, WithGetSipClient(cfg.GetSipClient), WithGetRoomClient(cfg.GetRoom))
-	client.SetHandler(&TestHandler{})
+	client.SetHandler(cfg.Handler)
 
 	// Set up service config with minimal values
 	localIP, err := config.GetLocalIP()

--- a/pkg/sip/outbound_utilities_test.go
+++ b/pkg/sip/outbound_utilities_test.go
@@ -498,7 +498,7 @@ func NewOutboundTestClient(t testing.TB, cfg TestClientConfig) *Client {
 			SIPPortListen:     5060,
 			ListenIP:          localIP.String(),
 			LocalNet:          localIP.String() + "/24",
-			RTPPort:           rtcconfig.PortRange{Start: 20000, End: 20010},
+			RTPPort:           rtcconfig.PortRange{Start: 20000, End: 30000},
 			MaxCpuUtilization: 0.99, // Higher threshold for tests to avoid false positives
 			WsUrl:             "ws://localhost:7880",
 			ApiKey:            "test-api-key",
@@ -542,7 +542,6 @@ func NewOutboundTestClient(t testing.TB, cfg TestClientConfig) *Client {
 	if cfg.Handler == nil {
 		cfg.Handler = &TestHandler{}
 	}
-
 	client := NewClient(cfg.Region, cfg.Config, log, cfg.Monitor, cfg.GetIOClient, WithGetSipClient(cfg.GetSipClient), WithGetRoomClient(cfg.GetRoom))
 	client.SetHandler(cfg.Handler)
 

--- a/pkg/sip/outbound_utilities_test.go
+++ b/pkg/sip/outbound_utilities_test.go
@@ -397,7 +397,7 @@ func (w *testSIPClient) TransactionRequest(req *sip.Request, options ...sipgo.Cl
 	w.sequence++
 	tx := &testSIPClientTransaction{
 		log:       w.log,
-		responses: make(chan *sip.Response),
+		responses: make(chan *sip.Response, 1),
 		cancels:   make(chan struct{}),
 		done:      make(chan struct{}),
 		err:       make(chan error),


### PR DESCRIPTION
Also in this PR:
- A couple of nil checks in outbound.go
  - Add a nil check against `*outboundCall.media` in `outboundCall.close` (if the call to `NewMediaPort` in `newCall` fails, then we'd hit this nil deref).
  - Add a nil check against the response returned from selecting from `tx.Responses` in `sipResponse.
- Make one of the outbound test utility channels buffered to avoid a race in the tests.
 