### PR TITLE
Allow SIPServer to be configured with interceptors.

### DIFF
--- a/pkg/sip/server.go
+++ b/pkg/sip/server.go
@@ -23,7 +23,7 @@ import (
 	"log/slog"
 	"net"
 	"net/netip"
-	"runtime/debug"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -142,6 +142,9 @@ type Handler interface {
 	OnSessionEnd(ctx context.Context, callIdentifier *CallIdentifier, state *CallState, reason string)
 }
 
+// HandlerInterceptor wraps a handler function.
+type HandlerInterceptor func(sipgo.RequestHandler) sipgo.RequestHandler
+
 type Server struct {
 	log             logger.Logger
 	mon             *stats.Monitor
@@ -166,9 +169,10 @@ type Server struct {
 		byLocalTag *expirable.LRU[LocalTag, *inboundCallInfo]
 	}
 
-	handler Handler
-	conf    *config.Config
-	sconf   *ServiceConfig
+	handler      Handler
+	conf         *config.Config
+	sconf        *ServiceConfig
+	interceptors []HandlerInterceptor
 
 	cli *Client // optional, for outbound reinvite handling
 
@@ -199,6 +203,15 @@ func WithGetRoomServer(fn GetRoomFunc) ServerOption {
 func WithClient(cli *Client) ServerOption {
 	return func(s *Server) {
 		s.cli = cli
+	}
+}
+
+// WithInterceptors configures all sip handlers to be wrapped with the given set
+// of interceptors. Interceptors are applied s.t. the first interceptor is the
+// outermost one.
+func WithInterceptors(interceptors ...HandlerInterceptor) ServerOption {
+	return func(s *Server) {
+		s.interceptors = interceptors
 	}
 }
 
@@ -308,27 +321,12 @@ func (s *Server) startTLS(addr netip.AddrPort, conf *tls.Config) error {
 
 type RequestHandler func(req *sip.Request, tx sip.ServerTransaction) bool
 
-// withRecovery wraps the given handler with a recover statement so that a panic
-// in the given handler does not crash the process.
-func (s *Server) withRecovery(handler sipgo.RequestHandler) sipgo.RequestHandler {
-	return func(log *slog.Logger, req *sip.Request, tx sip.ServerTransaction) {
-		defer func() {
-			if r := recover(); r != nil {
-				stack := debug.Stack()
-				err, ok := r.(error)
-				if !ok {
-					err = fmt.Errorf("%v", r)
-				}
-				method := req.Method.String()
-				fields := []any{"method", method, "stacktrace", string(stack)}
-				if h := req.CallID(); h != nil {
-					fields = append(fields, "sipCallID", h.Value())
-				}
-				s.log.Errorw("panic in SIP request handler", err, fields...)
-			}
-		}()
-		handler(log, req, tx)
+func (s *Server) wrapHandler(handler sipgo.RequestHandler) sipgo.RequestHandler {
+	ret := handler
+	for _, interceptor := range slices.Backward(s.interceptors) {
+		ret = interceptor(ret)
 	}
+	return ret
 }
 
 func (s *Server) Start(agent *sipgo.UserAgent, sc *ServiceConfig, tlsConf *tls.Config, unhandled RequestHandler) error {
@@ -354,12 +352,12 @@ func (s *Server) Start(agent *sipgo.UserAgent, sc *ServiceConfig, tlsConf *tls.C
 		return err
 	}
 
-	s.sipSrv.OnOptions(s.withRecovery(s.onOptions))
-	s.sipSrv.OnInvite(s.withRecovery(s.onInvite))
-	s.sipSrv.OnAck(s.withRecovery(s.onAck))
-	s.sipSrv.OnBye(s.withRecovery(s.onBye))
-	s.sipSrv.OnNotify(s.withRecovery(s.onNotify))
-	s.sipSrv.OnNoRoute(s.withRecovery(s.OnNoRoute))
+	s.sipSrv.OnOptions(s.wrapHandler(s.onOptions))
+	s.sipSrv.OnInvite(s.wrapHandler(s.onInvite))
+	s.sipSrv.OnAck(s.wrapHandler(s.onAck))
+	s.sipSrv.OnBye(s.wrapHandler(s.onBye))
+	s.sipSrv.OnNotify(s.wrapHandler(s.onNotify))
+	s.sipSrv.OnNoRoute(s.wrapHandler(s.OnNoRoute))
 	s.sipUnhandled = unhandled
 
 	listenIP := s.conf.ListenIP

--- a/pkg/sip/service.go
+++ b/pkg/sip/service.go
@@ -80,7 +80,7 @@ type Service struct {
 // is the SIPCallInfo that NewCallState will own immediately after.
 type GetStateHandler func(projectID string, obs *rpc.SIPCallObservability, initial *livekit.SIPCallInfo) StateHandler
 
-func NewService(region string, conf *config.Config, mon *stats.Monitor, log logger.Logger, getStateHandler GetStateHandler) (*Service, error) {
+func NewService(region string, conf *config.Config, mon *stats.Monitor, log logger.Logger, getStateHandler GetStateHandler, opts ...ServerOption) (*Service, error) {
 	if log == nil {
 		log = logger.GetLogger()
 	}
@@ -94,12 +94,13 @@ func NewService(region string, conf *config.Config, mon *stats.Monitor, log logg
 		conf.MediaTimeoutInitial = defaultMediaTimeoutInitial
 	}
 	cli := NewClient(region, conf, log, mon, getStateHandler)
+	options := append([]ServerOption{WithClient(cli)}, opts...)
 	s := &Service{
 		conf:             conf,
 		log:              log,
 		mon:              mon,
 		cli:              cli,
-		srv:              NewServer(region, conf, log, mon, getStateHandler, WithClient(cli)),
+		srv:              NewServer(region, conf, log, mon, getStateHandler, options...),
 		pendingTransfers: make(map[LocalTag]*PendingTransfer),
 	}
 	var err error

--- a/pkg/sip/service_test.go
+++ b/pkg/sip/service_test.go
@@ -127,7 +127,7 @@ func (h TestHandler) OnSessionEnd(ctx context.Context, callIdentifier *CallIdent
 	}
 }
 
-func testInvite(t *testing.T, h Handler, hidden bool, from, to string, test func(tx sip.ClientTransaction)) {
+func testInvite(t *testing.T, h Handler, hidden bool, from, to string, test func(tx sip.ClientTransaction), serverOpts ...ServerOption) {
 	sipPort := rand.Intn(testPortSIPMax-testPortSIPMin) + testPortSIPMin
 	localIP, err := config.GetLocalIP()
 	require.NoError(t, err)
@@ -144,7 +144,9 @@ func testInvite(t *testing.T, h Handler, hidden bool, from, to string, test func
 		SIPPort:         sipPort,
 		SIPPortListen:   sipPort,
 		RTPPort:         rtcconfig.PortRange{Start: testPortRTPMin, End: testPortRTPMax},
-	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler { return NewRPCStateHandler(nil) })
+	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler {
+		return NewRPCStateHandler(nil)
+	}, serverOpts...)
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	t.Cleanup(s.Stop)
@@ -286,7 +288,9 @@ func TestService_RejectedInviteCacheReplay(t *testing.T) {
 		SIPPort:       sipPort,
 		SIPPortListen: sipPort,
 		RTPPort:       rtcconfig.PortRange{Start: testPortRTPMin, End: testPortRTPMax},
-	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler { return NewRPCStateHandler(nil) })
+	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler {
+		return NewRPCStateHandler(nil)
+	})
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	s.SetHandler(h)
@@ -384,7 +388,9 @@ func TestService_OnSessionEnd(t *testing.T) {
 		SIPPort:       sipPort,
 		SIPPortListen: sipPort,
 		RTPPort:       rtcconfig.PortRange{Start: testPortRTPMin, End: testPortRTPMax},
-	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler { return NewRPCStateHandler(nil) })
+	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler {
+		return NewRPCStateHandler(nil)
+	})
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	t.Cleanup(s.Stop)
@@ -425,6 +431,60 @@ func TestService_OnSessionEnd(t *testing.T) {
 	require.Equal(t, expectedCallID, receivedCallInfo.CallId, "CallInfo.CallId should match")
 	require.Equal(t, expectedSipCallID, receivedCallInfo.ParticipantAttributes[AttrSIPCallIDFull], "CallInfo.ParticipantAttributes[sip.callIDFull] should match")
 	require.Equal(t, expectedReason, receivedReason, "Reason should match")
+}
+
+type interceptorRecorder struct {
+	mu   sync.Mutex
+	logs []string
+}
+
+func (l *interceptorRecorder) loggingInterceptor(name string) HandlerInterceptor {
+	return func(handler sipgo.RequestHandler) sipgo.RequestHandler {
+		return func(log *slog.Logger, req *sip.Request, tx sip.ServerTransaction) {
+			l.log(fmt.Sprintf("enter %s", name))
+			handler(log, req, tx)
+			l.log(fmt.Sprintf("exit %s", name))
+		}
+	}
+}
+
+func (l *interceptorRecorder) log(msg string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.logs = append(l.logs, msg)
+}
+
+func TestService_Interceptors(t *testing.T) {
+	h := &TestHandler{}
+	done := make(chan struct{}, 1)
+
+	sentinel := func(handler sipgo.RequestHandler) sipgo.RequestHandler {
+		return func(log *slog.Logger, req *sip.Request, tx sip.ServerTransaction) {
+			handler(log, req, tx)
+			done <- struct{}{}
+		}
+	}
+
+	recorder := &interceptorRecorder{}
+
+	testInvite(t, h, true, "from-user", "to-user", func(tx sip.ClientTransaction) {
+		res := getResponseOrFail(t, tx)
+		require.Equal(t, sip.StatusCode(180), res.StatusCode)
+	}, WithInterceptors(sentinel, recorder.loggingInterceptor("a"), recorder.loggingInterceptor("b")))
+
+	select {
+	case <-done:
+	case <-time.After(time.Second * 2):
+		t.Fatal("handler did not return")
+	}
+
+	wantLogs := []string{
+		"enter a",
+		"enter b",
+		"exit b",
+		"exit a",
+	}
+	require.ElementsMatch(t, wantLogs, recorder.logs)
 }
 
 // TestDigestAuthSimultaneousCalls tests that simultaneous calls from the same "from" number
@@ -488,7 +548,9 @@ func TestDigestAuthSimultaneousCalls(t *testing.T) {
 		SIPPort:         sipPort,
 		SIPPortListen:   sipPort,
 		RTPPort:         rtcconfig.PortRange{Start: testPortRTPMin, End: testPortRTPMax},
-	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler { return NewRPCStateHandler(nil) })
+	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler {
+		return NewRPCStateHandler(nil)
+	})
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	t.Cleanup(s.Stop)
@@ -695,7 +757,9 @@ func TestDigestAuthStandardFlow(t *testing.T) {
 		SIPPort:         sipPort,
 		SIPPortListen:   sipPort,
 		RTPPort:         rtcconfig.PortRange{Start: testPortRTPMin, End: testPortRTPMax},
-	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler { return NewRPCStateHandler(nil) })
+	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler {
+		return NewRPCStateHandler(nil)
+	})
 	require.NoError(t, err)
 	require.NotNil(t, s)
 	t.Cleanup(s.Stop)
@@ -949,7 +1013,9 @@ func TestSameCallIDForAuthFlow(t *testing.T) {
 		SIPPort:         sipPort,
 		SIPPortListen:   sipPort,
 		RTPPort:         rtcconfig.PortRange{Start: testPortRTPMin, End: testPortRTPMax},
-	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler { return NewRPCStateHandler(nil) })
+	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler {
+		return NewRPCStateHandler(nil)
+	})
 	require.NoError(t, err)
 	require.NotNil(t, s)
 


### PR DESCRIPTION
Currently, the SIP server is configured so that each handler is automatically wrapped with a panic recovery interceptor. This PR removes the panic interceptors and allows SIP servers to be configured with arbitrary interceptors (so as to provide greater flexibility to users). Also, allow update `NewService` so that callers might specify options to be passed to the underlying server.