### PR TITLE
Fix flaky TestService_Interceptors.

### DIFF
--- a/pkg/sip/service_test.go
+++ b/pkg/sip/service_test.go
@@ -474,10 +474,45 @@ func TestService_Interceptors(t *testing.T) {
 
 	recorder := &interceptorRecorder{}
 
-	testInvite(t, h, true, "from-user", "to-user", func(tx sip.ClientTransaction) {
-		res := getResponseOrFail(t, tx)
-		require.Equal(t, sip.StatusCode(180), res.StatusCode)
+	sipPort := rand.Intn(testPortSIPMax-testPortSIPMin) + testPortSIPMin
+	localIP, err := config.GetLocalIP()
+	require.NoError(t, err)
+	sipServerAddress := fmt.Sprintf("%s:%d", localIP, sipPort)
+
+	mon, err := stats.NewMonitor(&config.Config{MaxCpuUtilization: 0.9})
+	require.NoError(t, err)
+
+	// Use a no-op logger to avoid panics from async logging after test completion
+	log := logger.LogRLogger(logr.Discard())
+	s, err := NewService("", &config.Config{
+		HideInboundPort: false,
+		SIPPort:         sipPort,
+		SIPPortListen:   sipPort,
+		RTPPort:         rtcconfig.PortRange{Start: testPortRTPMin, End: testPortRTPMax},
+	}, mon, log, func(projectID string, _ *rpc.SIPCallObservability, _ *livekit.SIPCallInfo) StateHandler {
+		return NewRPCStateHandler(nil)
 	}, WithInterceptors(sentinel, recorder.loggingInterceptor("a"), recorder.loggingInterceptor("b")))
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	t.Cleanup(s.Stop)
+	s.SetHandler(h)
+	require.NoError(t, s.Start())
+
+	sipUserAgent, err := sipgo.NewUA(
+		sipgo.WithUserAgent("from-user"),
+		sipgo.WithUserAgentLogger(slog.New(logger.ToSlogHandler(s.log))),
+	)
+	require.NoError(t, err)
+
+	client, err := sipgo.NewClient(sipUserAgent)
+	require.NoError(t, err)
+	recipient := sip.Uri{Host: sipServerAddress}
+	req := sip.NewRequest(sip.OPTIONS, recipient)
+	req.SetDestination(sipServerAddress)
+	req.AppendHeader(sip.NewHeader("Content-Type", "application/sdp"))
+	tx, err := client.TransactionRequest(req)
+	require.NoError(t, err)
+	t.Cleanup(tx.Terminate)
 
 	select {
 	case <-done:
@@ -491,7 +526,7 @@ func TestService_Interceptors(t *testing.T) {
 		"exit b",
 		"exit a",
 	}
-	require.ElementsMatch(t, wantLogs, recorder.get())
+	require.Equal(t, wantLogs, recorder.get())
 }
 
 // TestDigestAuthSimultaneousCalls tests that simultaneous calls from the same "from" number


### PR DESCRIPTION
`TestService_Interceptors` tests to ensure that the server's interceptors are chained together properly.

Previously, this test's sip client was sending an INVITE the server, which the server would then respond with a 180 ringing message, at which point, the test would proceed to verify that a certain set of interceptors had been fired. There was a potential race, though, as, after the server returned a 180 (ringing), at some point, it would return a 486 (rejected) message to the client, at which point, the client would ACK the the 486. The test was not set up to synchronize on the 486 response and the subsequent ACK, and so, sometimes, the interceptor logs would include logs for this subsequent ACK message, and, sometimes they wouldn't. Specifically, sequences like this would cause the test to fail:

1. Client sends invite
2. Invite interceptors run (enter)
3. Server sends 180 (ringing) response
4. Client sees ringing response
5. Server sends 486 (rejected) response
6. Invite interceptors run (exit)
7. Client sends ack
8. Ack interceptors run (enter)
9. Server responds with ack
10. Ack interceptors run (exit)
11. Test fails due to the ack interceptors being in the logs

Fix the test by sending an OPTIONS request so as to avoid having to update the test to synchronize on the client re-acking the request.

`go test ./pkg/sip/... -run "TestService_Interceptors" -count 100 -race` passes.