### PR TITLE
Allow the SIP status for a call that rings out to be configured

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,8 +36,9 @@ import (
 )
 
 const (
-	DefaultSIPPort    int = 5060
-	DefaultSIPPortTLS int = 5061
+	DefaultSIPPort              int = 5060
+	DefaultSIPPortTLS           int = 5061
+	DefaultRingingTimeoutStatus int = 486 // Busy Here
 )
 
 var (
@@ -94,6 +95,7 @@ type Config struct {
 	SIPHostname          string              `yaml:"sip_hostname"`
 	OutboundRouteHeaders []string            `yaml:"outbound_route_headers"` // Route headers prepended to outbound requests, e.g. "<sip:proxy:5060;transport=tcp;lr>"
 	SIPRingingInterval   time.Duration       `yaml:"sip_ringing_interval"`   // from 1 sec up to 60 (default '1s')
+	RingingTimeoutStatus int                 `yaml:"ringing_timeout_status"` // status when a call rings out, 3xx-6xx (default '486')
 	TCP                  *TCPConfig          `yaml:"tcp"`
 	TLS                  *TLSConfig          `yaml:"tls"`
 	RTPPort              rtcconfig.PortRange `yaml:"rtp_port"`
@@ -207,6 +209,12 @@ func (c *Config) Init() error {
 	}
 	if c.MaxCpuUtilization <= 0 || c.MaxCpuUtilization > 1 {
 		c.MaxCpuUtilization = 0.9
+	}
+	if c.RingingTimeoutStatus == 0 {
+		c.RingingTimeoutStatus = DefaultRingingTimeoutStatus
+	} else if c.RingingTimeoutStatus < 300 || c.RingingTimeoutStatus > 699 {
+		return psrpc.NewErrorf(psrpc.InvalidArgument,
+			"ringing_timeout_status must be a SIP failure status between 300 and 699, got %d", c.RingingTimeoutStatus)
 	}
 
 	if err := c.InitLogger(); err != nil {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1226,7 +1226,11 @@ func (c *inboundCall) waitSubscribe(ctx context.Context, timeout time.Duration) 
 		c.close(ctx, end)
 		return false, psrpc.NewErrorf(psrpc.Canceled, "rpc terminated the call")
 	case <-timer.C:
-		c.closeWithTerm(ctx, stats.ServerError("cannot-subscribe"))
+		c.close(ctx, EndCall{
+			Status: callDropped,
+			Term:   stats.ServerError("cannot-subscribe"),
+			Code:   sip.StatusCode(c.s.conf.RingingTimeoutStatus),
+		})
 		return false, psrpc.NewErrorf(psrpc.DeadlineExceeded, "room subscription timed out")
 	case <-c.lkRoom.Subscribed():
 		return true, nil
@@ -1367,6 +1371,9 @@ func (c *inboundCall) close(ctx context.Context, end EndCall) {
 			Code:   sip.StatusRequestTerminated,
 			Status: "Request Terminated",
 		}
+	}
+	if end.Code != 0 {
+		result = Result{Code: end.Code}
 	}
 	log := c.log().WithValues("status", result.Code, "result", string(end.Term.Result), "reason", end.Term.Reason)
 	defer func() {

--- a/pkg/sip/protocol.go
+++ b/pkg/sip/protocol.go
@@ -63,6 +63,7 @@ type EndCall struct {
 	Term    stats.Termination
 	Reason  livekit.DisconnectReason // disconnect reason for LiveKit participant
 	Headers map[string]string        // extra headers to send to SIP peer
+	Code    sip.StatusCode           // SIP status for an unanswered call; zero picks the default
 }
 
 var statusNamesMap = map[int]string{

--- a/pkg/sip/service_test.go
+++ b/pkg/sip/service_test.go
@@ -995,6 +995,51 @@ func TestCANCELSendsBothResponses(t *testing.T) {
 	}
 }
 
+// A call that rings for the whole ringing timeout without the room ever subscribing
+// is rejected with ringing_timeout_status, or 486 Busy Here when it is not configured.
+func TestRingingTimeoutStatus(t *testing.T) {
+	cases := []struct {
+		name     string
+		configed int
+		expected sip.StatusCode
+	}{
+		{name: "unconfigured", configed: 0, expected: sip.StatusBusyHere},
+		{name: "configured", configed: 480, expected: sip.StatusTemporarilyUnavailable},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := &TestHandler{
+				DispatchCallFunc: func(ctx context.Context, info *CallInfo) CallDispatch {
+					identity := fmt.Sprintf("test-participant-%s", info.Call.SipCallId)
+					return CallDispatch{
+						Result:         DispatchAccept,
+						RingingTimeout: 500 * time.Millisecond,
+						Room: RoomConfig{
+							RoomName: "test-room",
+							Participant: ParticipantConfig{
+								Identity: identity,
+								Name:     identity,
+							},
+						},
+					}
+				},
+			}
+			st := NewServiceTest(t, &serviceTestConfig{
+				GetRoom: newTestRoomConfig(&testRoomConfig{ringForever: true}),
+				Handler: h,
+			})
+			st.Server.conf.RingingTimeoutStatus = c.configed
+
+			call := newTestCall(st.TestUA, false)
+			req, _, err := call.Invite(nil)
+			require.NoError(t, err)
+
+			resp := st.TestUA.TransactionRequest(t, req, true)
+			require.Equal(t, c.expected, resp.StatusCode)
+		})
+	}
+}
+
 // TestSameCallIDForAuthFlow verifies that the same LiveKit call ID is assigned to both
 // the initial INVITE (without auth) and the subsequent INVITE (with auth)
 func TestSameCallIDForAuthFlow(t *testing.T) {

--- a/pkg/sip/signaling_test.go
+++ b/pkg/sip/signaling_test.go
@@ -423,6 +423,7 @@ type serviceTest struct {
 
 type serviceTestConfig struct {
 	GetRoom GetRoomFunc
+	Handler Handler
 }
 
 func NewServiceTest(t *testing.T, options *serviceTestConfig) *serviceTest {
@@ -433,6 +434,9 @@ func NewServiceTest(t *testing.T, options *serviceTestConfig) *serviceTest {
 	}
 	if options.GetRoom == nil {
 		options.GetRoom = newTestRoomConfig(nil)
+	}
+	if options.Handler == nil {
+		options.Handler = &TestHandler{}
 	}
 
 	sipPort := rand.Intn(testPortSIPMax-testPortSIPMin) + testPortSIPMin
@@ -492,7 +496,7 @@ func NewServiceTest(t *testing.T, options *serviceTestConfig) *serviceTest {
 		MediaIP:          loopback,
 	}
 
-	handler := &TestHandler{}
+	handler := options.Handler
 
 	err = srv.Start(nil, sconf, nil, cli.OnRequest)
 	require.NoError(t, err)


### PR DESCRIPTION
Currently, when a call rings out after the ringing period the `INVITE` is rejected with a `486 Busy Here`.

It would be convenient in our use case to allow a different code, such as a `503 Service Unavailable` to be sent instead so that twilio fails over - it doesn't fail over on a 486.

This PR adds a `ringing_timeout_status` option which defaults to the current 486.