### PR TITLE
Update inbound.go outbound.go to use new MediaPort interface.

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -404,26 +404,29 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	s.cmu.RLock()
 	existing := s.byLocalTag[cc.ID()]
 	s.cmu.RUnlock()
-	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
+	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() && existing.media != nil {
 		existing.log().Infow("reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 		if _, err = existing.media.GenerateAnswer(sdpBodyFromRequest(req)); err != nil {
 			log.Errorw("failed to update outbound call SDP", err)
+			return err
 		}
 
+		// TODO(rework): Reply with the new SDP.
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
 	}
 	if s.cli != nil { // Process reinvite for existing outbound calls
 		oc := s.cli.getActiveCall(cc.ID())
 		newCSeq := cc.InviteCSeq()
-		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq {
+		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq && oc.media != nil {
 			if localSDP, err := oc.media.GetLocalSDP(); err == nil && len(localSDP) > 0 {
 				oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 				if _, err = oc.media.GenerateAnswer(sdpBodyFromRequest(req)); err != nil {
 					log.Errorw("failed to update outbound call SDP", err)
-					return nil
+					return err
 				}
 				oc.cc.RecordInvite(newCSeq)
+				// TODO(rework): Reply with the new SDP.
 				cc.AcceptAsKeepAlive(localSDP)
 				return nil
 			}

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -73,6 +73,7 @@ const (
 var allowHeader = sip.NewHeader("Allow", "INVITE, ACK, CANCEL, BYE, NOTIFY, REFER, MESSAGE, OPTIONS, INFO, SUBSCRIBE")
 
 var errNoACK = errors.New("no ACK received for 200 OK")
+var errInternal = errors.New("internal error")
 
 // hashPassword creates a SHA256 hash of the password for logging purposes
 func hashPassword(password string) string {
@@ -417,19 +418,25 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	if s.cli != nil { // Process reinvite for existing outbound calls
 		oc := s.cli.getActiveCall(cc.ID())
 		newCSeq := cc.InviteCSeq()
-		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq && oc.media != nil {
-			localSDP, err := oc.media.GetLocalSDP() // eror
-			if err == nil && len(localSDP) > 0 {
-				oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-				if err := oc.updateRemoteFromSDP(sdpBodyFromRequest(req)); err != nil {
-					log.Errorw("failed to update outbound call SDP", err)
-					return err
-				}
-				oc.cc.RecordInvite(newCSeq)
-				// TODO(alexfish): Reply with the new SDP.
-				cc.AcceptAsKeepAlive(localSDP)
-				return nil
+		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq {
+			if oc.media == nil {
+				oc.log.Errorw("outbound call media has not been negotiated", nil)
+				return errInternal
 			}
+			localSDP, err := oc.media.GetLocalSDP()
+			if err != nil || len(localSDP) == 0 {
+				oc.log.Errorw("outbound call does not have an SDP", nil)
+				return errInternal
+			}
+			oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
+			if err := oc.updateRemoteFromSDP(sdpBodyFromRequest(req)); err != nil {
+				log.Errorw("failed to update outbound call SDP", err)
+				return errInternal
+			}
+			oc.cc.RecordInvite(newCSeq)
+			// TODO(alexfish): Reply with the new SDP.
+			cc.AcceptAsKeepAlive(localSDP)
+			return nil
 		}
 
 	}

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -417,9 +417,9 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	if s.cli != nil { // Process reinvite for existing outbound calls
 		oc := s.cli.getActiveCall(cc.ID())
 		newCSeq := cc.InviteCSeq()
-		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq {
-			localSDP := oc.GetLocalSDP()
-			if len(localSDP) > 0 {
+		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq && oc.media != nil {
+			localSDP, err := oc.media.GetLocalSDP() // eror
+			if err == nil && len(localSDP) > 0 {
 				oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 				if err := oc.updateRemoteFromSDP(sdpBodyFromRequest(req)); err != nil {
 					log.Errorw("failed to update outbound call SDP", err)

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -404,33 +404,34 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	s.cmu.RLock()
 	existing := s.byLocalTag[cc.ID()]
 	s.cmu.RUnlock()
-	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() && existing.media != nil {
+	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
 		existing.log().Infow("reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-		if _, err = existing.media.GenerateAnswer(sdpBodyFromRequest(req)); err != nil {
-			log.Errorw("failed to update outbound call SDP", err)
+		if err := existing.updateRemoteFromSDP(sdpBodyFromRequest(req)); err != nil {
+			log.Errorw("failed to update inbound call SDP", err)
 			return err
 		}
-
-		// TODO(rework): Reply with the new SDP.
+		// TODO(alexfish): Reply with the new SDP.
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
 	}
 	if s.cli != nil { // Process reinvite for existing outbound calls
 		oc := s.cli.getActiveCall(cc.ID())
 		newCSeq := cc.InviteCSeq()
-		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq && oc.media != nil {
-			if localSDP, err := oc.media.GetLocalSDP(); err == nil && len(localSDP) > 0 {
+		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq {
+			localSDP := oc.GetLocalSDP()
+			if len(localSDP) > 0 {
 				oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-				if _, err = oc.media.GenerateAnswer(sdpBodyFromRequest(req)); err != nil {
+				if err := oc.updateRemoteFromSDP(sdpBodyFromRequest(req)); err != nil {
 					log.Errorw("failed to update outbound call SDP", err)
 					return err
 				}
 				oc.cc.RecordInvite(newCSeq)
-				// TODO(rework): Reply with the new SDP.
+				// TODO(alexfish): Reply with the new SDP.
 				cc.AcceptAsKeepAlive(localSDP)
 				return nil
 			}
 		}
+
 	}
 
 	from, to := cc.From(), cc.To()
@@ -1507,6 +1508,20 @@ func (c *inboundCall) Close() error {
 // close() is idempotent via c.done, so concurrent paths cannot double-emit.
 func (c *inboundCall) Shutdown(ctx context.Context) {
 	c.closeWithTerm(ctx, stats.ServerError("shutdown"))
+}
+
+func (c *inboundCall) updateRemoteFromSDP(body []byte) error {
+	var mp MediaPort
+
+	c.mmu.Lock()
+	mp = c.media
+	c.mmu.Unlock()
+
+	if mp == nil {
+		return nil
+	}
+	_, err := mp.GenerateAnswer(body)
+	return err
 }
 
 func (c *inboundCall) closeMedia() {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -406,7 +406,10 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
 		existing.log().Infow("reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-		existing.updateRemoteFromSDP(sdpBodyFromRequest(req))
+		if _, err = existing.media.GenerateAnswer(sdpBodyFromRequest(req)); err != nil {
+			log.Errorw("failed to update outbound call SDP", err)
+		}
+
 		cc.AcceptAsKeepAlive(existing.cc.OwnSDP())
 		return nil
 	}
@@ -414,10 +417,12 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 		oc := s.cli.getActiveCall(cc.ID())
 		newCSeq := cc.InviteCSeq()
 		if oc != nil && oc.cc != nil && oc.cc.InviteCSeq() < newCSeq {
-			localSDP := oc.cc.LocalSDP()
-			if len(localSDP) != 0 {
+			if localSDP, err := oc.media.GetLocalSDP(); err == nil && len(localSDP) > 0 {
 				oc.log.Infow("accepting reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
-				oc.updateRemoteFromSDP(sdpBodyFromRequest(req))
+				if _, err = oc.media.GenerateAnswer(sdpBodyFromRequest(req)); err != nil {
+					log.Errorw("failed to update outbound call SDP", err)
+					return nil
+				}
 				oc.cc.RecordInvite(newCSeq)
 				cc.AcceptAsKeepAlive(localSDP)
 				return nil
@@ -709,6 +714,7 @@ type inboundCall struct {
 	sigTs       SignalingTimestamps
 	jitterBuf   bool
 	projectID   string
+	audioOut    *msdk.WriteCloserSwitch[msdk.PCM16Sample]
 }
 
 func (s *Server) newInboundCall(
@@ -738,6 +744,7 @@ func (s *Server) newInboundCall(
 		endCall:    make(chan EndCall, 1),
 		jitterBuf:  SelectValueBool(s.conf.EnableJitterBuffer, s.conf.EnableJitterBufferProb),
 		projectID:  "", // Will be set in handleInvite when available
+		audioOut:   msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate),
 	}
 	c.stats.Update()
 	c.setLog(log.WithValues("jitterBuf", c.jitterBuf))
@@ -960,8 +967,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 			// Start this timer right after the Accept.
 			ackTimeout = time.After(inviteOkAckLateTimeout)
 		}
-		c.media.EnableTimeout(true)
-		c.media.EnableOut()
+		c.audioOut.Swap(c.media.GetAudioWriter())
 		if ok, err := c.waitMedia(ctx); !ok {
 			return false, err
 		}
@@ -1079,7 +1085,7 @@ func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan str
 			})
 			c.closeWithTerm(ctx, terminationFromRoomDisconnect(roomReason))
 			return nil
-		case <-c.media.Timeout():
+		case <-c.media.MediaTimeout():
 			return c.mediaTimeout(ctx)
 		case <-ackReceived:
 			ackTimeout = nil // all good, disable timeout
@@ -1088,12 +1094,33 @@ func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan str
 			// Only warn, the other side still thinks the call is active, media may be flowing.
 			c.log().Warnw("Call accepted, but no ACK received", errNoACK)
 			// We don't need to wait for a full media timeout initially, we already know something is not quite right.
-			c.media.SetTimeout(min(inviteOkAckLateTimeout, c.s.conf.MediaTimeoutInitial), mediaTimeout)
+			c.media.SetTimeoutForDelayedAck(min(inviteOkAckLateTimeout, c.s.conf.MediaTimeoutInitial), mediaTimeout)
 		}
 	}
 }
 
-func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, mconf *sipMediaConfig, conf *config.Config, features []livekit.SIPFeature, featureFlags map[string]string) (answerData []byte, _ error) {
+type dtmfEventWriter struct {
+	handler func(msg *livekit.SipDTMF)
+}
+
+func (w *dtmfEventWriter) String() string {
+	return "dtmfEventWriter"
+}
+
+func (w *dtmfEventWriter) SampleRate() int {
+	return dtmf.SampleRate
+}
+
+func (w *dtmfEventWriter) Close() error {
+	return nil
+}
+
+func (w *dtmfEventWriter) WriteSample(sample *livekit.SipDTMF) error {
+	w.handler(sample)
+	return nil
+}
+
+func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, mconf *sipMediaConfig, conf *config.Config, features []livekit.SIPFeature, featureFlags map[string]string) ([]byte, error) {
 	c.mmu.Lock()
 	defer c.mmu.Unlock()
 	c.mon.SDPSize(len(offerData), true)
@@ -1122,35 +1149,30 @@ func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, mconf *sipM
 	}
 	c.media = mp
 	c.mediaCodecs = mconf.Codecs
-	mp.EnableTimeout(false) // enabled once we accept the call
-	mp.DisableOut()         // disabled until we send 200
 
 	answerData, err := mp.GenerateAnswer(offerData)
 	if err != nil {
 		return nil, err
 	}
+
 	c.mon.SDPSize(len(answerData), false)
 	c.log().Debugw("SDP answer", "sdp", string(answerData))
 
-	mc.Processor = c.s.handler.GetMediaProcessor(features, featureFlags, string(c.cc.ID()), MediaProcessorOpts{InputSampleRate: c.media.InputSampleRate()})
-
-	if mc.Audio.DTMFType != 0 {
-		mp.HandleDTMF(c.handleDTMF)
-	}
+	mp.WriteDTMFTo(&dtmfEventWriter{handler: c.handleDTMF})
 
 	// Must be set earlier to send the pin prompts.
-	if w := c.lkRoom.SwapOutput(mp.GetAudioWriter()); w != nil {
+	if w := c.lkRoom.SwapOutput(c.audioOut); w != nil {
 		_ = w.Close()
 	}
-	if mc.Audio.DTMFType != 0 {
-		c.lkRoom.SetDTMFOutput(mp.GetDTMFWriter())
+	c.lkRoom.SetDTMFOutput(c.media.GetDTMFWriter())
+
+	if audio := mp.NegotiatedAudio(); audio != nil {
+		c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
+			info.AudioCodec = audio.Codec.Info().SDPName
+		})
 	}
-	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
-		info.AudioCodec = mc.Audio.Codec.Info().SDPName
-	})
 	return answerData, nil
 }
-
 func (c *inboundCall) waitMedia(ctx context.Context) (bool, error) {
 	defer c.mon.StageDurTimer("wait-media")()
 	ctx, span := Tracer.Start(ctx, "sip.inbound.waitMedia")
@@ -1599,17 +1621,33 @@ func (c *inboundCall) playAudio(ctx context.Context, frames []msdk.PCM16Sample) 
 	_ = msdk.PlayAudio[msdk.PCM16Sample](ctx, t, rtp.DefFrameDur, frames)
 }
 
-func (c *inboundCall) handleDTMF(tone dtmf.Event) {
+func (c *inboundCall) handleDTMF(msg *livekit.SipDTMF) {
+	if msg == nil {
+		return
+	}
+
+	code := byte(msg.Code)
+	digit := byte(0)
+	if len(msg.Digit) == 1 {
+		digit = msg.Digit[0]
+	} else {
+		digit = dtmf.CodeToChar(code)
+	}
+	event := dtmf.Event{
+		Code:  code,
+		Digit: digit,
+	}
+
 	if c.forwardDTMF.Load() {
 		_ = c.lkRoom.SendData(&livekit.SipDTMF{
-			Code:  uint32(tone.Code),
-			Digit: string([]byte{tone.Digit}),
+			Code:  uint32(code),
+			Digit: string([]byte{digit}),
 		}, lksdk.WithDataPublishReliable(true))
 		return
 	}
 	// We should have enough buffer here.
 	select {
-	case c.dtmf <- tone:
+	case c.dtmf <- event:
 	default:
 	}
 }
@@ -1639,9 +1677,7 @@ func (c *inboundCall) transferCall(ctx context.Context, transferTo string, heade
 		}()
 
 		go func() {
-			aw := c.media.GetAudioWriter()
-
-			err := tones.Play(rctx, aw, ringVolume, tones.ETSIRinging)
+			err := tones.Play(rctx, c.audioOut, ringVolume, tones.ETSIRinging)
 			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				c.log().Infow("cannot play dial tone", "error", err)
 			}

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -725,8 +725,7 @@ type inboundCall struct {
 	sigTs            SignalingTimestamps
 	jitterBuf        bool
 	projectID        string
-	audioOut         *msdk.WriteCloserSwitch[msdk.PCM16Sample]
-	audioIn          *msdk.WriteCloserSwitch[msdk.PCM16Sample]
+	audioOut         *msdk.WriteCloserSwitch[msdk.PCM16Sample] // inner writer owned by MediaPort
 	audioInProcessor msdk.PCM16Processor
 }
 
@@ -758,7 +757,6 @@ func (s *Server) newInboundCall(
 		jitterBuf:  SelectValueBool(s.conf.EnableJitterBuffer, s.conf.EnableJitterBufferProb),
 		projectID:  "", // Will be set in handleInvite when available
 		audioOut:   msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate),
-		audioIn:    msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate), // TODO(alexfish): Close this.
 	}
 	c.stats.Update()
 	c.setLog(log.WithValues("jitterBuf", c.jitterBuf))
@@ -981,7 +979,10 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 			// Start this timer right after the Accept.
 			ackTimeout = time.After(inviteOkAckLateTimeout)
 		}
-		c.audioOut.Swap(c.media.GetAudioWriter())
+		if old := c.audioOut.Swap(c.media.GetAudioWriter()); old != nil {
+			c.log().Warnw("unexpected audio out writer", nil)
+			old.Close()
+		}
 		if ok, err := c.waitMedia(ctx); !ok {
 			return false, err
 		}
@@ -1417,9 +1418,6 @@ func (c *inboundCall) close(ctx context.Context, end EndCall) {
 	if callDurFn := c.callDur; callDurFn != nil {
 		callDurFn()
 	}
-	if old := c.audioIn.Swap(nil); old != nil {
-		old.Close()
-	}
 	c.s.cmu.Lock()
 	delete(c.s.byLocalTag, c.cc.ID())
 	c.s.cmu.Unlock()
@@ -1614,13 +1612,11 @@ func (c *inboundCall) publishTrack() error {
 		_ = c.lkRoom.Close()
 		return err
 	}
+
 	if c.audioInProcessor != nil {
 		local = c.audioInProcessor(local)
 	}
-	if old := c.audioIn.Swap(local); old != nil {
-		old.Close()
-	}
-	c.media.WriteAudioTo(c.audioIn)
+	c.media.WriteAudioTo(local)
 	return nil
 }
 

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1114,6 +1114,7 @@ func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan str
 	}
 }
 
+// TODO(alexfish): Update Room so that we don't need this adapater.
 type dtmfEventWriter struct {
 	handler func(msg *livekit.SipDTMF)
 }

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -697,35 +697,37 @@ func (s *Server) onNotify(log *slog.Logger, req *sip.Request, tx sip.ServerTrans
 }
 
 type inboundCall struct {
-	s           *Server
-	tid         traceid.ID
-	logPtr      atomic.Pointer[logger.Logger]
-	cc          *sipInbound
-	mon         *stats.CallMonitor
-	state       *CallState
-	callStart   time.Time
-	extraAttrs  map[string]string
-	attrsToHdr  map[string]string
-	ctx         context.Context
-	cancel      func()
-	closeReason atomic.Pointer[ReasonHeader]
-	call        *rpc.SIPCall
-	mmu         sync.Mutex
-	media       MediaPort
-	mediaCodecs *msdk.CodecSet
-	dtmf        chan dtmf.Event // buffered
-	endCall     chan EndCall    // buffered
-	lkRoom      RoomInterface   // LiveKit room; only active after correct pin is entered
-	callDur     func() time.Duration
-	joinDur     func() time.Duration
-	forwardDTMF atomic.Bool
-	done        atomic.Bool
-	started     core.Fuse
-	stats       Stats
-	sigTs       SignalingTimestamps
-	jitterBuf   bool
-	projectID   string
-	audioOut    *msdk.WriteCloserSwitch[msdk.PCM16Sample]
+	s                *Server
+	tid              traceid.ID
+	logPtr           atomic.Pointer[logger.Logger]
+	cc               *sipInbound
+	mon              *stats.CallMonitor
+	state            *CallState
+	callStart        time.Time
+	extraAttrs       map[string]string
+	attrsToHdr       map[string]string
+	ctx              context.Context
+	cancel           func()
+	closeReason      atomic.Pointer[ReasonHeader]
+	call             *rpc.SIPCall
+	mmu              sync.Mutex
+	media            MediaPort
+	mediaCodecs      *msdk.CodecSet
+	dtmf             chan dtmf.Event // buffered
+	endCall          chan EndCall    // buffered
+	lkRoom           RoomInterface   // LiveKit room; only active after correct pin is entered
+	callDur          func() time.Duration
+	joinDur          func() time.Duration
+	forwardDTMF      atomic.Bool
+	done             atomic.Bool
+	started          core.Fuse
+	stats            Stats
+	sigTs            SignalingTimestamps
+	jitterBuf        bool
+	projectID        string
+	audioOut         *msdk.WriteCloserSwitch[msdk.PCM16Sample]
+	audioIn          *msdk.WriteCloserSwitch[msdk.PCM16Sample]
+	audioInProcessor msdk.PCM16Processor
 }
 
 func (s *Server) newInboundCall(
@@ -756,6 +758,7 @@ func (s *Server) newInboundCall(
 		jitterBuf:  SelectValueBool(s.conf.EnableJitterBuffer, s.conf.EnableJitterBufferProb),
 		projectID:  "", // Will be set in handleInvite when available
 		audioOut:   msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate),
+		audioIn:    msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate), // TODO(alexfish): Close this.
 	}
 	c.stats.Update()
 	c.setLog(log.WithValues("jitterBuf", c.jitterBuf))
@@ -1169,6 +1172,7 @@ func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, mconf *sipM
 	c.mon.SDPSize(len(answerData), false)
 	c.log().Debugw("SDP answer", "sdp", string(answerData))
 
+	c.audioInProcessor = c.s.handler.GetMediaProcessor(features, featureFlags, string(c.cc.ID()), MediaProcessorOpts{InputSampleRate: RoomSampleRate})
 	mp.WriteDTMFTo(&dtmfEventWriter{handler: c.handleDTMF})
 
 	// Must be set earlier to send the pin prompts.
@@ -1177,11 +1181,13 @@ func (c *inboundCall) runMediaConn(tid traceid.ID, offerData []byte, mconf *sipM
 	}
 	c.lkRoom.SetDTMFOutput(c.media.GetDTMFWriter())
 
-	if audio := mp.NegotiatedAudio(); audio != nil {
-		c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
-			info.AudioCodec = audio.Codec.Info().SDPName
-		})
+	audio := mp.NegotiatedAudio()
+	if audio == nil {
+		return nil, fmt.Errorf("media does not have negotiated audio")
 	}
+	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
+		info.AudioCodec = audio.Codec.Info().SDPName
+	})
 	return answerData, nil
 }
 func (c *inboundCall) waitMedia(ctx context.Context) (bool, error) {
@@ -1411,6 +1417,9 @@ func (c *inboundCall) close(ctx context.Context, end EndCall) {
 	if callDurFn := c.callDur; callDurFn != nil {
 		callDurFn()
 	}
+	if old := c.audioIn.Swap(nil); old != nil {
+		old.Close()
+	}
 	c.s.cmu.Lock()
 	delete(c.s.byLocalTag, c.cc.ID())
 	c.s.cmu.Unlock()
@@ -1605,7 +1614,13 @@ func (c *inboundCall) publishTrack() error {
 		_ = c.lkRoom.Close()
 		return err
 	}
-	c.media.WriteAudioTo(local)
+	if c.audioInProcessor != nil {
+		local = c.audioInProcessor(local)
+	}
+	if old := c.audioIn.Swap(local); old != nil {
+		old.Close()
+	}
+	c.media.WriteAudioTo(c.audioIn)
 	return nil
 }
 

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -654,7 +654,6 @@ func (p *mediaPort) timeoutLoop() {
 
 func (p *mediaPort) closePipelineLocked() {
 	// Lock must already be held
-	// p.audioIn & p.dtmfIn are set by external sources, need to be externally closed
 
 	// Close switch -> port
 	if closer := p.audioOut.Swap(nil); closer != nil {

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -394,18 +394,21 @@ type MediaPort interface {
 	GetDTMFWriter() msdk.WriteCloser[*livekit.SipDTMF]
 	WriteDTMFTo(w msdk.WriteCloser[*livekit.SipDTMF]) msdk.WriteCloser[*livekit.SipDTMF]
 
-	// GenerateOffer returns an encoded SDP offer. Returns an error if an offer
-	// has been already been generated or media has already been negotiated.
+	// If there is no offer, this generates an offer.
+	// If there is an offer, this simply returns the SDP of that offer.
+	// An offer is cleared once a negotiation is successful.
 	GenerateOffer() ([]byte, error)
 
 	// GenerateAnswer returns an encoded SDP answer for the given offer.
 	//
-	// SIDE EFFECT: Rebuilds the media pipeline.
+	// SIDE EFFECT: May cause a rebuild of the pipeline.
 	GenerateAnswer(offer []byte) ([]byte, error)
 
 	// ProcessAnswer processes an encoded SDP answer from the remote client. Returns an
 	// error if the answer is invalid, the offer has not yet been generated, or
 	// if media has already been negotiated.
+	//
+	// SIDE EFFECT: May cause a rebuild of the pipeline.
 	ProcessAnswer(answer []byte) error
 
 	GetLocalSDP() ([]byte, error)
@@ -424,7 +427,7 @@ type MediaPort interface {
 	//
 	// We would like to enforce the fact that all invites must be ACKed.
 	// Sometimes, though, for whatever reason, we do not see ACKs for invites
-	// (presumably, this is due to an issue within sipfe). In such cases where
+	// (e.g due to possible issues with load balancing). In such cases where
 	// we require an invite to be ACKed (guarded by the `InboundWaitACK`
 	// setting), if we don't see the ACK within some amount of time, then we
 	// restrict the timeout with this method so that the call might end earlier

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -394,10 +394,42 @@ type MediaPort interface {
 	GetDTMFWriter() msdk.WriteCloser[*livekit.SipDTMF]
 	WriteDTMFTo(w msdk.WriteCloser[*livekit.SipDTMF]) msdk.WriteCloser[*livekit.SipDTMF]
 
+	// GenerateOffer returns an encoded SDP offer. Returns an error if an offer
+	// has been already been generated or media has already been negotiated.
 	GenerateOffer() ([]byte, error)
+
+	// GenerateAnswer returns an encoded SDP answer for the given offer.
+	//
+	// SIDE EFFECT: Rebuilds the media pipeline.
 	GenerateAnswer(offer []byte) ([]byte, error)
+
+	// ProcessAnswer processes an encoded SDP answer from the remote client. Returns an
+	// error if the answer is invalid, the offer has not yet been generated, or
+	// if media has already been negotiated.
 	ProcessAnswer(answer []byte) error
+
 	GetLocalSDP() ([]byte, error)
+
+	// NegotiatedAudio returns the audio configuration chosen by SDP negotiation.
+	// Returns nil if media has not been negotiated yet.
+	//
+	// REQUIRES: The caller should not mutate the returned audio config.
+	NegotiatedAudio() *sdp.AudioConfig
+
+	// SetTimeout resets the media timeout with the given values.
+	//
+	// NOTE: This method will be removed at some point in the future and is only
+	// used by one caller. Do not call this method: specify media timeout
+	// settings when constructing a MediaPort.
+	//
+	// We would like to enforce the fact that all invites must be ACKed.
+	// Sometimes, though, for whatever reason, we do not see ACKs for invites
+	// (presumably, this is due to an issue within sipfe). In such cases where
+	// we require an invite to be ACKed (guarded by the `InboundWaitACK`
+	// setting), if we don't see the ACK within some amount of time, then we
+	// restrict the timeout with this method so that the call might end earlier
+	// than if the timeout were never shortened.
+	SetTimeoutForDelayedAck(initial, general time.Duration)
 
 	Received() <-chan struct{}
 	MediaTimeout() <-chan struct{}
@@ -467,10 +499,11 @@ type mediaPort struct {
 	codecs           *msdk.CodecSet
 	encryption       sdp.Encryption
 
-	mu       sync.RWMutex
-	pipeline *mediaPortPipeline
-	localSDP []byte
-	offer    *sdp.Offer
+	mu        sync.RWMutex
+	pipeline  *mediaPortPipeline
+	localSDP  []byte
+	offer     *sdp.Offer
+	audioConf *sdp.AudioConfig
 
 	audioIn  *msdk.WriteCloserSwitch[msdk.PCM16Sample] // SIP RTP -> LK PCM
 	audioOut *msdk.WriteCloserSwitch[msdk.PCM16Sample] // LK PCM -> SIP RTP
@@ -483,12 +516,6 @@ func (p *mediaPort) kickTimeoutLoop() {
 	case p.timeoutKick <- struct{}{}:
 	default: // already pending
 	}
-}
-
-func (p *mediaPort) disableTimeout() {
-	p.log.Debugw("media timeout disabled")
-	p.timeoutStart.Store(nil)
-	p.kickTimeoutLoop()
 }
 
 func (p *mediaPort) enableTimeout(initial, general time.Duration) {
@@ -513,15 +540,11 @@ func (p *mediaPort) enableTimeout(initial, general time.Duration) {
 	p.kickTimeoutLoop()
 }
 
-func (p *mediaPort) EnableTimeout(enabled bool) {
-	if !enabled {
-		p.disableTimeout()
-		return
-	}
+func (p *mediaPort) enableTimeoutWithDefaults() {
 	p.enableTimeout(p.opts.MediaTimeoutInitial, p.opts.MediaTimeout)
 }
 
-func (p *mediaPort) SetTimeout(initial, general time.Duration) {
+func (p *mediaPort) SetTimeoutForDelayedAck(initial, general time.Duration) {
 	p.enableTimeout(initial, general)
 }
 
@@ -794,6 +817,12 @@ func (p *mediaPort) GetLocalSDP() ([]byte, error) {
 	return p.localSDP, nil
 }
 
+func (p *mediaPort) NegotiatedAudio() *sdp.AudioConfig {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.audioConf
+}
+
 // Building pipeline
 
 func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
@@ -858,6 +887,8 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 	}
 	p.offer = nil // Pipeline build done, can now proceed to offer anew
 	p.localSDP = localSDP
+	p.audioConf = &c.Audio
+	p.enableTimeoutWithDefaults()
 	return nil
 }
 

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -801,6 +801,7 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 	return nil
 }
 
+// TODO(alexfish): Update Room so that we don't need this adapter.
 func (c *outboundCall) handleDTMF(msg *livekit.SipDTMF) {
 	if c.lkRoom == nil {
 		return

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -773,15 +773,18 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 	}
 
 	c.setExtraAttrs(c.sipConf.headersToAttrs, c.sipConf.includeHeaders, c.cc, nil)
-	if audio := c.media.NegotiatedAudio(); audio != nil {
-		c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
-			info.AudioCodec = audio.Codec.Info().SDPName
-			if r := c.lkRoom.Room(); r != nil {
-				info.ParticipantAttributes = r.LocalParticipant.Attributes() // clones
-			}
-		})
-
+	audio := c.media.NegotiatedAudio()
+	if audio == nil {
+		return fmt.Errorf("call media does not have negotiated audio")
 	}
+
+	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
+		info.AudioCodec = audio.Codec.Info().SDPName
+		if r := c.lkRoom.Room(); r != nil {
+			info.ParticipantAttributes = r.LocalParticipant.Attributes() // clones
+		}
+	})
+
 	return nil
 }
 

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -82,11 +82,12 @@ type outboundCall struct {
 	jitterBuf bool
 	projectID string
 
-	mu       sync.RWMutex
-	mon      *stats.CallMonitor
-	lkRoom   RoomInterface
-	lkRoomIn msdk.PCM16Writer // output to room; OPUS at 48k
-	sipConf  sipOutboundConfig
+	mu               sync.RWMutex
+	mon              *stats.CallMonitor
+	lkRoom           RoomInterface
+	lkRoomIn         msdk.PCM16Writer // output to room; OPUS at 48k
+	sipConf          sipOutboundConfig
+	audioInProcessor msdk.PCM16Processor
 }
 
 func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Config, log logger.Logger, id LocalTag, room RoomConfig, sipConf sipOutboundConfig, state *CallState, projectID string) (*outboundCall, error) {
@@ -386,6 +387,9 @@ func (c *outboundCall) close(ctx context.Context, end EndCall) bool {
 			_ = r.CloseOutput()
 			_ = r.CloseWithReason(end.Status.DisconnectReason())
 		}
+		if err := c.lkRoomIn.Close(); err != nil {
+			log.Warnw("error closing livekit room audio input", err)
+		}
 		c.lkRoomIn = nil
 
 		c.c.cmu.Lock()
@@ -470,6 +474,9 @@ func (c *outboundCall) connectToRoom(ctx context.Context, lkNew RoomConfig, getR
 		return err
 	}
 	c.lkRoom = r
+	if c.audioInProcessor != nil {
+		local = c.audioInProcessor(local)
+	}
 	c.lkRoomIn = local
 	if err := registerSignalingRPC(c.lkRoom, c.cc); err != nil {
 		return err
@@ -508,8 +515,6 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 		return err
 	}
 
-	var errs []error
-
 	if digits := c.sipConf.dtmf; digits != "" {
 		c.setStatus(CallAutomation)
 		// Write initial DTMF to SIP
@@ -518,13 +523,12 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 			if err := dtmfWriter.WriteSample(&livekit.SipDTMF{
 				Digit: string(digits[i]),
 			}); err != nil {
-				errs = append(errs, fmt.Errorf("error writing digit no. %d (%s): %w", i, string(digits[i]), err))
+				return fmt.Errorf("error writing digits (%s): %w", string(digits[i]))
 			}
 		}
 	}
 	c.setStatus(CallActive)
-
-	return errors.Join(errs...)
+	return nil
 }
 
 func (c *outboundCall) updateRemoteFromSDP(body []byte) error {
@@ -755,6 +759,8 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 	if err != nil {
 		return err
 	}
+
+	c.audioInProcessor = c.c.handler.GetMediaProcessor(c.sipConf.enabledFeatures, c.sipConf.featureFlags, string(c.cc.ID()), MediaProcessorOpts{InputSampleRate: RoomSampleRate})
 
 	c.mon.InviteAccept()
 	err = c.cc.AckInviteOK(ctx)

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -518,7 +518,7 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 			if err := dtmfWriter.WriteSample(&livekit.SipDTMF{
 				Digit: string(digits[i]),
 			}); err != nil {
-				errs = append(errs, fmt.Errorf("error writing digit no. %d (%q): %w", i, string(digits), err))
+				errs = append(errs, fmt.Errorf("error writing digit no. %d (%s): %w", i, string(digits[i]), err))
 			}
 		}
 	}
@@ -539,13 +539,6 @@ func (c *outboundCall) updateRemoteFromSDP(body []byte) error {
 	}
 	_, err := mp.GenerateAnswer(body)
 	return err
-}
-
-func (c *outboundCall) GetLocalSDP() []byte {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	sdp, _ := c.media.GetLocalSDP()
-	return sdp
 }
 
 func (c *outboundCall) connectMedia() {

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -508,19 +508,23 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 		return err
 	}
 
+	var errs []error
+
 	if digits := c.sipConf.dtmf; digits != "" {
 		c.setStatus(CallAutomation)
 		// Write initial DTMF to SIP
 		dtmfWriter := c.media.GetDTMFWriter()
 		for i := range len(digits) {
-			dtmfWriter.WriteSample(&livekit.SipDTMF{
+			if err := dtmfWriter.WriteSample(&livekit.SipDTMF{
 				Digit: string(digits[i]),
-			})
+			}); err != nil {
+				errs = append(errs, fmt.Errorf("error writing digit no. %d (%q): %w", i, string(digits), err))
+			}
 		}
 	}
 	c.setStatus(CallActive)
 
-	return nil
+	return errors.Join(errs...)
 }
 
 func (c *outboundCall) connectMedia() {

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -86,9 +86,7 @@ type outboundCall struct {
 	mon      *stats.CallMonitor
 	lkRoom   RoomInterface
 	lkRoomIn msdk.PCM16Writer // output to room; OPUS at 48k
-
-	sipConf sipOutboundConfig
-
+	sipConf  sipOutboundConfig
 	audioOut *msdk.WriteCloserSwitch[msdk.PCM16Sample] // inner writer owned by MediaPort
 }
 

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -527,6 +527,27 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 	return errors.Join(errs...)
 }
 
+func (c *outboundCall) updateRemoteFromSDP(body []byte) error {
+	var mp MediaPort
+
+	c.mu.Lock()
+	mp = c.media
+	c.mu.Unlock()
+
+	if mp == nil {
+		return nil
+	}
+	_, err := mp.GenerateAnswer(body)
+	return err
+}
+
+func (c *outboundCall) GetLocalSDP() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sdp, _ := c.media.GetLocalSDP()
+	return sdp
+}
+
 func (c *outboundCall) connectMedia() {
 	if w := c.lkRoom.SwapOutput(c.media.GetAudioWriter()); w != nil {
 		_ = w.Close()

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -82,12 +82,14 @@ type outboundCall struct {
 	jitterBuf bool
 	projectID string
 
-	mu               sync.RWMutex
-	mon              *stats.CallMonitor
-	lkRoom           RoomInterface
-	lkRoomIn         msdk.PCM16Writer // output to room; OPUS at 48k
-	sipConf          sipOutboundConfig
-	audioInProcessor msdk.PCM16Processor
+	mu       sync.RWMutex
+	mon      *stats.CallMonitor
+	lkRoom   RoomInterface
+	lkRoomIn msdk.PCM16Writer // output to room; OPUS at 48k
+
+	sipConf sipOutboundConfig
+
+	audioOut *msdk.WriteCloserSwitch[msdk.PCM16Sample] // inner writer owned by MediaPort
 }
 
 func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Config, log logger.Logger, id LocalTag, room RoomConfig, sipConf sipOutboundConfig, state *CallState, projectID string) (*outboundCall, error) {
@@ -116,6 +118,7 @@ func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Confi
 		sigTs:     SignalingTimestamps{APITime: now},
 		jitterBuf: jitterBuf,
 		projectID: projectID,
+		audioOut:  msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate), // inner writer owned by MediaPort
 	}
 	call.stats.Update()
 	call.cc = c.newOutbound(log, id, sipConf.uri, sipConf.to, sipConf.from, contact, call.setAttrsToHeaders)
@@ -387,8 +390,11 @@ func (c *outboundCall) close(ctx context.Context, end EndCall) bool {
 			_ = r.CloseOutput()
 			_ = r.CloseWithReason(end.Status.DisconnectReason())
 		}
-		if err := c.lkRoomIn.Close(); err != nil {
-			log.Warnw("error closing livekit room audio input", err)
+
+		if c.lkRoomIn != nil {
+			if err := c.lkRoomIn.Close(); err != nil {
+				log.Warnw("error closing livekit room audio input", err)
+			}
 		}
 		c.lkRoomIn = nil
 
@@ -474,9 +480,6 @@ func (c *outboundCall) connectToRoom(ctx context.Context, lkNew RoomConfig, getR
 		return err
 	}
 	c.lkRoom = r
-	if c.audioInProcessor != nil {
-		local = c.audioInProcessor(local)
-	}
 	c.lkRoomIn = local
 	if err := registerSignalingRPC(c.lkRoom, c.cc); err != nil {
 		return err
@@ -519,12 +522,10 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 		c.setStatus(CallAutomation)
 		// Write initial DTMF to SIP
 		dtmfWriter := c.media.GetDTMFWriter()
-		for i := range len(digits) {
-			if err := dtmfWriter.WriteSample(&livekit.SipDTMF{
-				Digit: string(digits[i]),
-			}); err != nil {
-				return fmt.Errorf("error writing digits (%s): %w", string(digits[i]))
-			}
+		if err := dtmfWriter.WriteSample(&livekit.SipDTMF{
+			Digit: digits,
+		}); err != nil {
+			return fmt.Errorf("error writing digits (%s): %w", digits, err)
 		}
 	}
 	c.setStatus(CallActive)
@@ -546,11 +547,14 @@ func (c *outboundCall) updateRemoteFromSDP(body []byte) error {
 }
 
 func (c *outboundCall) connectMedia() {
-	if w := c.lkRoom.SwapOutput(c.media.GetAudioWriter()); w != nil {
+	if w := c.lkRoom.SwapOutput(c.audioOut); w != nil {
 		_ = w.Close()
 	}
 	c.lkRoom.SetDTMFOutput(c.media.GetDTMFWriter())
 
+	if processor := c.c.handler.GetMediaProcessor(c.sipConf.enabledFeatures, c.sipConf.featureFlags, string(c.cc.ID()), MediaProcessorOpts{InputSampleRate: RoomSampleRate}); processor != nil {
+		c.lkRoomIn = processor(c.lkRoomIn)
+	}
 	c.media.WriteAudioTo(c.lkRoomIn)
 	c.media.WriteDTMFTo(&dtmfEventWriter{handler: c.handleDTMF})
 }
@@ -760,9 +764,12 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 		return err
 	}
 
-	c.audioInProcessor = c.c.handler.GetMediaProcessor(c.sipConf.enabledFeatures, c.sipConf.featureFlags, string(c.cc.ID()), MediaProcessorOpts{InputSampleRate: RoomSampleRate})
-
 	c.mon.InviteAccept()
+	if old := c.audioOut.Swap(c.media.GetAudioWriter()); old != nil {
+		c.log.Warnw("unexpected audio out writer", nil)
+		old.Close()
+	}
+
 	err = c.cc.AckInviteOK(ctx)
 	if err != nil {
 		c.log.Infow("SIP accept failed", "error", err)
@@ -844,9 +851,7 @@ func (c *outboundCall) transferCall(ctx context.Context, transferTo string, head
 		}()
 
 		go func() {
-			aw := c.media.GetAudioWriter()
-
-			err := tones.Play(rctx, aw, ringVolume, tones.ETSIRinging)
+			err := tones.Play(rctx, c.audioOut, ringVolume, tones.ETSIRinging)
 			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				c.log.Infow("cannot play dial tone", "error", err)
 			}

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -150,8 +150,6 @@ func (c *Client) newCall(ctx context.Context, tid traceid.ID, conf *config.Confi
 		})
 		return nil, err
 	}
-	call.media.EnableTimeout(false)
-	call.media.DisableOut() // disabled until we get 200
 	if err := call.connectToRoom(ctx, room, c.getRoom); err != nil {
 		call.close(ctx, EndCall{
 			Report: fmt.Errorf("room join failed: %w", err),
@@ -513,8 +511,11 @@ func (c *outboundCall) dialSIP(ctx context.Context, tid traceid.ID) error {
 	if digits := c.sipConf.dtmf; digits != "" {
 		c.setStatus(CallAutomation)
 		// Write initial DTMF to SIP
-		if err := c.media.WriteDTMF(ctx, digits); err != nil {
-			return err
+		dtmfWriter := c.media.GetDTMFWriter()
+		for i := range len(digits) {
+			dtmfWriter.WriteSample(&livekit.SipDTMF{
+				Digit: string(digits[i]),
+			})
 		}
 	}
 	c.setStatus(CallActive)
@@ -529,7 +530,7 @@ func (c *outboundCall) connectMedia() {
 	c.lkRoom.SetDTMFOutput(c.media.GetDTMFWriter())
 
 	c.media.WriteAudioTo(c.lkRoomIn)
-	c.media.WriteDTMFTo(c.handleDTMF)
+	c.media.WriteDTMFTo(&dtmfEventWriter{handler: c.handleDTMF})
 }
 
 type sipRespFunc func(code sip.StatusCode, hdrs Headers)
@@ -737,8 +738,6 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 		return err
 	}
 
-	mc.Processor = c.c.handler.GetMediaProcessor(c.sipConf.enabledFeatures, c.sipConf.featureFlags, string(c.cc.ID()), MediaProcessorOpts{InputSampleRate: c.media.InputSampleRate()})
-
 	c.mon.InviteAccept()
 	err = c.cc.AckInviteOK(ctx)
 	if err != nil {
@@ -756,22 +755,38 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 	}
 
 	c.setExtraAttrs(c.sipConf.headersToAttrs, c.sipConf.includeHeaders, c.cc, nil)
-	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
-		info.AudioCodec = mc.Audio.Codec.Info().SDPName
-		if r := c.lkRoom.Room(); r != nil {
-			info.ParticipantAttributes = r.LocalParticipant.Attributes() // clones
-		}
-	})
+	if audio := c.media.NegotiatedAudio(); audio != nil {
+		c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
+			info.AudioCodec = audio.Codec.Info().SDPName
+			if r := c.lkRoom.Room(); r != nil {
+				info.ParticipantAttributes = r.LocalParticipant.Attributes() // clones
+			}
+		})
+
+	}
 	return nil
 }
 
-func (c *outboundCall) handleDTMF(ev dtmf.Event) {
+func (c *outboundCall) handleDTMF(msg *livekit.SipDTMF) {
 	if c.lkRoom == nil {
 		return
 	}
+
+	if msg == nil {
+		return
+	}
+
+	code := byte(msg.Code)
+	digit := byte(0)
+	if len(msg.Digit) == 1 {
+		digit = msg.Digit[0]
+	} else {
+		digit = dtmf.CodeToChar(code)
+	}
+
 	_ = c.lkRoom.SendData(&livekit.SipDTMF{
-		Code:  uint32(ev.Code),
-		Digit: string([]byte{ev.Digit}),
+		Code:  uint32(code),
+		Digit: string([]byte{digit}),
 	}, lksdk.WithDataPublishReliable(true))
 }
 

--- a/pkg/sip/room.go
+++ b/pkg/sip/room.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pion/webrtc/v4"
 
 	msdk "github.com/livekit/media-sdk"
-	"github.com/livekit/media-sdk/dtmf"
 	"github.com/livekit/media-sdk/g711"
 	"github.com/livekit/media-sdk/jitter"
 	"github.com/livekit/media-sdk/mixer"
@@ -188,7 +187,7 @@ type RoomInterface interface {
 	Output() msdk.Writer[msdk.PCM16Sample]
 	SwapOutput(out msdk.PCM16Writer) msdk.PCM16Writer
 	CloseOutput() error
-	SetDTMFOutput(w dtmf.Writer)
+	SetDTMFOutput(w msdk.WriteCloser[*livekit.SipDTMF])
 	Close() error
 	CloseWithReason(reason livekit.DisconnectReason) error
 	Participant() ParticipantInfo
@@ -211,7 +210,7 @@ type Room struct {
 	room    atomic.Pointer[lksdk.Room]
 	mix     *mixer.Mixer
 	out     *msdk.SwitchWriter
-	outDtmf atomic.Pointer[dtmf.Writer]
+	outDtmf atomic.Pointer[msdk.WriteCloser[*livekit.SipDTMF]]
 	// p is replaced on every reconnect, since the server issues a new
 	// participant SID, and read concurrently by Participant().
 	p          atomic.Pointer[ParticipantInfo]
@@ -700,7 +699,7 @@ func (r *Room) CloseOutput() error {
 	return w.Close()
 }
 
-func (r *Room) SetDTMFOutput(w dtmf.Writer) {
+func (r *Room) SetDTMFOutput(w msdk.WriteCloser[*livekit.SipDTMF]) {
 	if r == nil {
 		return
 	}
@@ -718,10 +717,8 @@ func (r *Room) sendDTMF(ctx context.Context, msg *livekit.SipDTMF) {
 		return
 	}
 	// TODO: Separate goroutine?
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 	r.log.Debugw("forwarding dtmf to sip", "digit", msg.Digit)
-	_ = (*outDTMF).WriteDTMF(ctx, msg.Digit)
+	(*outDTMF).WriteSample(msg)
 }
 
 func (r *Room) Close() error {


### PR DESCRIPTION
- Update the `MediaPort` interface to accommodate a few things within inbound.go
  - Add a `NegotiatedAudio` method to return the audio settings (if configured). We need this to update the `SIPCallInfo` in inbound.go and outbound.go
  - Add a `SetTimeoutForDelayedAck` method: see code comment for full details.
  -Added a few TODOs in places where we might need to send an updated SDP on re-INVITE.