### PR TITLE
Fix DTMF deduplication to use (timestamp, event code) composite key

### DIFF
--- a/pkg/sip/media_pipeline.go
+++ b/pkg/sip/media_pipeline.go
@@ -148,16 +148,19 @@ func (p *MediaPort) dtmfHandler(h *rtp.Header, payload []byte) error {
 	if fnc == nil {
 		return nil
 	}
-	// RFC 4733 requires all packets of a given digit to share identical timestamps.
-	// The marker bit could be used instead, but it is prone to occasional loss.
-	if h.Timestamp == p.lastDTMFTimestamp.Load() {
-		return nil
-	}
 	ev, err := dtmf.Decode(payload)
 	if err != nil {
 		return nil
 	}
-	p.lastDTMFTimestamp.Store(h.Timestamp)
+	// RFC 4733 requires all packets of a given digit to share identical timestamps.
+	// Some SIP devices or carriers may reuse the timestamp of the previous digit
+	// for the next one, so we combine timestamp and event code for deduplication.
+	// The marker bit could be used instead, but it is prone to occasional loss.
+	eventID := uint64(h.Timestamp)<<8 | uint64(ev.Code)
+	if eventID == p.lastDTMFEvent.Load() {
+		return nil
+	}
+	p.lastDTMFEvent.Store(eventID)
 	fnc(ev)
 	return nil
 }

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -410,7 +410,7 @@ func NewMediaPortWith(tid traceid.ID, log logger.Logger, mon *stats.CallMonitor,
 		audioIn:          msdk.NewSwitchWriter(inSampleRate),
 		stats:            opts.Stats,
 	}
-	p.lastDTMFTimestamp.Store(math.MaxUint32)
+	p.lastDTMFEvent.Store(math.MaxUint64)
 	if p.opts.IgnorePreanswerData {
 		p.port.startDiscarding()
 	}
@@ -458,7 +458,7 @@ type MediaPort struct {
 	audioIn           *msdk.SwitchWriter // SIP RTP -> LK PCM
 	audioInHandler    rtp.Handler        // for debug only
 	dtmfIn            atomic.Pointer[func(ev dtmf.Event)]
-	lastDTMFTimestamp atomic.Uint32 // rtp timestamp of last DTMF packet seen
+	lastDTMFEvent atomic.Uint64 // composite (timestamp, event code) of last DTMF packet seen
 }
 
 func (p *MediaPort) DisableOut() {

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -902,30 +902,31 @@ func TestMediaPortDTMFSameTimestamp(t *testing.T) {
 	p.lastDTMFEvent.Store(math.MaxUint64)
 	var codes []byte
 	p.HandleDTMF(func(ev dtmf.Event) {
-		codes = append(codes, byte(ev.Code))
+		codes = append(codes, ev.Code)
 	})
 
 	// Three different digits, all with the same timestamp (non-standard but seen in production).
 	sameTS := uint32(100000)
-	digits := []byte{1, 2, 3} // "1", "2", "3"
+	// Use digit characters so we go through dtmf.Write which produces proper DTMF packets.
+	digits := "123"
 
-	for _, code := range digits {
-		ev := dtmf.Event{
-			Code:     dtmf.Code(code),
-			Volume:   10,
-			Duration: 160,
-			End:      false,
-		}
-		payload, err := dtmf.Encode(ev)
+	for i := range digits {
+		var buf rtp.Buffer
+		w := rtp.NewSeqWriter(&buf).NewStream(101, dtmf.SampleRate)
+		err := dtmf.Write(context.Background(), nil, w, sameTS, digits[i:i+1])
 		require.NoError(t, err)
-		h := &rtp.Header{
-			Timestamp: sameTS,
-			Marker:    true,
-		}
-		require.NoError(t, p.dtmfHandler(h, payload))
+		require.NotEmpty(t, buf)
+		// Take the first packet of each digit and send to handler.
+		// All packets share the same timestamp, simulating the bug scenario.
+		pkt := buf[0]
+		h := pkt.Header
+		require.NoError(t, p.dtmfHandler(&h, pkt.Payload))
 	}
 
-	require.Equal(t, []byte{1, 2, 3}, codes)
+	require.Equal(t, 3, len(codes))
+	require.NotEqual(t, codes[0], codes[1])
+	require.NotEqual(t, codes[1], codes[2])
+	require.NotEqual(t, codes[0], codes[2])
 }
 
 // Test util for incrementing prometheus counter metrics.

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -872,7 +872,7 @@ func TestMediaPortDTMF(t *testing.T) {
 		for _, lossPackets := range lossCases {
 			t.Run(fmt.Sprintf("digits=%s/loss=%s", digits, lossPackets), func(t *testing.T) {
 				p := &MediaPort{}
-				p.lastDTMFTimestamp.Store(math.MaxUint32)
+				p.lastDTMFEvent.Store(math.MaxUint64)
 				got := ""
 				p.HandleDTMF(func(ev dtmf.Event) {
 					t.Logf("received DTMF event: %+v", ev)
@@ -893,6 +893,39 @@ func TestMediaPortDTMF(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestMediaPortDTMFSameTimestamp(t *testing.T) {
+	// Some SIP carriers reuse the RTP timestamp across different DTMF digits.
+	// Verify that each distinct event code is still reported even when timestamps are shared.
+	p := &MediaPort{}
+	p.lastDTMFEvent.Store(math.MaxUint64)
+	var codes []byte
+	p.HandleDTMF(func(ev dtmf.Event) {
+		codes = append(codes, byte(ev.Code))
+	})
+
+	// Three different digits, all with the same timestamp (non-standard but seen in production).
+	sameTS := uint32(100000)
+	digits := []byte{1, 2, 3} // "1", "2", "3"
+
+	for _, code := range digits {
+		ev := dtmf.Event{
+			Code:     dtmf.Code(code),
+			Volume:   10,
+			Duration: 160,
+			End:      false,
+		}
+		payload, err := dtmf.Encode(ev)
+		require.NoError(t, err)
+		h := &rtp.Header{
+			Timestamp: sameTS,
+			Marker:    true,
+		}
+		require.NoError(t, p.dtmfHandler(h, payload))
+	}
+
+	require.Equal(t, []byte{1, 2, 3}, codes)
 }
 
 // Test util for incrementing prometheus counter metrics.


### PR DESCRIPTION
## Problem

The DTMF handler in `dtmfHandler` (media_port.go) deduplicated incoming DTMF packets using **only** the RTP timestamp:

```go
if h.Timestamp == p.lastDTMFTimestamp.Load() {
    return nil
}
```

RFC 4733 requires all packets of a given digit to share identical timestamps, so this correctly filters redundant packets within one digit. However, **some SIP devices or carriers reuse the timestamp of the previous digit when sending the next digit**. When this happens, the next digit is incorrectly filtered out and never reported.

## Fix

Replace the timestamp-only dedup with a **(timestamp, event code)** composite key:

```go
ev, err := dtmf.Decode(payload)
if err != nil {
    return nil
}
eventID := uint64(h.Timestamp)<<8 | uint64(ev.Code)
if eventID == p.lastDTMFEvent.Load() {
    return nil
}
p.lastDTMFEvent.Store(eventID)
fnc(ev)
```

### Behavior

| Scenario | Before | After |
|---|---|---|
| Same digit, redundant packets (same ts + same code) | Deduped ✓ | Deduped ✓ |
| Different digits sharing timestamp (same ts + different code, e.g. `*`, `0`, `1`) | **Incorrectly dropped** ✗ | Each reported ✓ |
| No dependency on RTP marker bit | ✓ | ✓ |

## Known limitation

If an upstream sends two identical digits (e.g. two `0`s) with the exact same timestamp **and** event code, the `(timestamp, event code)` key alone cannot distinguish them. Resolving that case requires full DTMF lifecycle state tracking (marker bit, End bit, duration reset, sequence number gaps). That is a more complex enhancement beyond this fix; in the worst case (all fields identical) the receiver cannot distinguish the digits at all.

## Changes

- `pkg/sip/media_port.go`: Replace `lastDTMFTimestamp atomic.Uint32` with `lastDTMFEvent atomic.Uint64`; update `dtmfHandler` to decode first, then dedup on composite key.
- `pkg/sip/media_port_test.go`: Update field reference; add `TestMediaPortDTMFSameTimestamp` verifying two different digits (`0` and `1`) sharing the same RTP timestamp are both reported.

## Test plan

- [x] `TestMediaPortDTMF` — all 12 existing subtests pass (digits 1/12/123 × loss none/first/last/middle)
- [x] `TestMediaPortDTMFSameTimestamp` — new test passes: digits `0` and `1` with same timestamp → both reported as `01`