### PR TITLE
TEL-886: Prep for reconfigure, re-introduce timeout control

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/icholy/digest v1.1.0
 	github.com/jfreymuth/oggvorbis v1.0.5
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
-	github.com/livekit/media-sdk v0.0.0-20260812193843-5a5218b19550
+	github.com/livekit/media-sdk v0.0.0-20260819173206-fbbca031700b
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
 	github.com/livekit/protocol v1.48.1-0.20260624204523-bd5703442db6
 	github.com/livekit/psrpc v0.7.2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/icholy/digest v1.1.0
 	github.com/jfreymuth/oggvorbis v1.0.5
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
-	github.com/livekit/media-sdk v0.0.0-20260819184418-4918ad225ae3
+	github.com/livekit/media-sdk v0.0.0-20260819185502-8cd8492db728
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
 	github.com/livekit/protocol v1.48.1-0.20260624204523-bd5703442db6
 	github.com/livekit/psrpc v0.7.2

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/icholy/digest v1.1.0
 	github.com/jfreymuth/oggvorbis v1.0.5
 	github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731
-	github.com/livekit/media-sdk v0.0.0-20260819173206-fbbca031700b
+	github.com/livekit/media-sdk v0.0.0-20260819184418-4918ad225ae3
 	github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0
 	github.com/livekit/protocol v1.48.1-0.20260624204523-bd5703442db6
 	github.com/livekit/psrpc v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/livekit/amrwb-cgo v0.0.0-20260612153743-6d4b69dc1470 h1:pYml12Ue55jDh
 github.com/livekit/amrwb-cgo v0.0.0-20260612153743-6d4b69dc1470/go.mod h1:nGBFrVVLyO0RlyM2pWnP/VKaZO6W3rzecL/YlkTPkW8=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5ATTo469PQPkqzdoU7be46ryiCDO3boc=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/media-sdk v0.0.0-20260819173206-fbbca031700b h1:/oIu2Me6JRHxF5jOE+uQJJIWhb1wKKmEHGOtY00Ej04=
-github.com/livekit/media-sdk v0.0.0-20260819173206-fbbca031700b/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
+github.com/livekit/media-sdk v0.0.0-20260819184418-4918ad225ae3 h1:6Ayw/pbshMkqi0hIv10+L9tJcPS8XDDqBVC6d9fzkO4=
+github.com/livekit/media-sdk v0.0.0-20260819184418-4918ad225ae3/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
 github.com/livekit/protocol v1.48.1-0.20260624204523-bd5703442db6 h1:Z23fxGEJJS3akyX2Q6LGo5xfL+B+NcEBhOp5o0Cz5IE=

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/livekit/amrwb-cgo v0.0.0-20260612153743-6d4b69dc1470 h1:pYml12Ue55jDh
 github.com/livekit/amrwb-cgo v0.0.0-20260612153743-6d4b69dc1470/go.mod h1:nGBFrVVLyO0RlyM2pWnP/VKaZO6W3rzecL/YlkTPkW8=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5ATTo469PQPkqzdoU7be46ryiCDO3boc=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/media-sdk v0.0.0-20260812193843-5a5218b19550 h1:aqaMkSNcx2GqCPsmGpkBN6MT5mlVyPZTECw5CxTAxOc=
-github.com/livekit/media-sdk v0.0.0-20260812193843-5a5218b19550/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
+github.com/livekit/media-sdk v0.0.0-20260819173206-fbbca031700b h1:/oIu2Me6JRHxF5jOE+uQJJIWhb1wKKmEHGOtY00Ej04=
+github.com/livekit/media-sdk v0.0.0-20260819173206-fbbca031700b/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
 github.com/livekit/protocol v1.48.1-0.20260624204523-bd5703442db6 h1:Z23fxGEJJS3akyX2Q6LGo5xfL+B+NcEBhOp5o0Cz5IE=

--- a/go.sum
+++ b/go.sum
@@ -130,8 +130,8 @@ github.com/livekit/amrwb-cgo v0.0.0-20260612153743-6d4b69dc1470 h1:pYml12Ue55jDh
 github.com/livekit/amrwb-cgo v0.0.0-20260612153743-6d4b69dc1470/go.mod h1:nGBFrVVLyO0RlyM2pWnP/VKaZO6W3rzecL/YlkTPkW8=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731 h1:9x+U2HGLrSw5ATTo469PQPkqzdoU7be46ryiCDO3boc=
 github.com/livekit/mageutil v0.0.0-20250511045019-0f1ff63f7731/go.mod h1:Rs3MhFwutWhGwmY1VQsygw28z5bWcnEYmS1OG9OxjOQ=
-github.com/livekit/media-sdk v0.0.0-20260819184418-4918ad225ae3 h1:6Ayw/pbshMkqi0hIv10+L9tJcPS8XDDqBVC6d9fzkO4=
-github.com/livekit/media-sdk v0.0.0-20260819184418-4918ad225ae3/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
+github.com/livekit/media-sdk v0.0.0-20260819185502-8cd8492db728 h1:reI1PPZE3kZhCLfVT4x869uRjulePiwchJ741GHeryE=
+github.com/livekit/media-sdk v0.0.0-20260819185502-8cd8492db728/go.mod h1:TuYRjSepaakL6ATsM9V2VMuksewW1PlhA32BG7Pxty0=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0 h1:XHNNzebIKZRkLimla/hFGrAIX5EMWHctrgt3hLw7s+I=
 github.com/livekit/mediatransportutil v0.0.0-20260608063931-a3417d38cda0/go.mod h1:o8CFmAdrVwzJNOCsQCLUzXRjokkufNshnQHOe4fRaqU=
 github.com/livekit/protocol v1.48.1-0.20260624204523-bd5703442db6 h1:Z23fxGEJJS3akyX2Q6LGo5xfL+B+NcEBhOp5o0Cz5IE=

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -967,6 +967,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 			})
 			return false, err
 		}
+		c.media.SetTimeout(c.s.conf.MediaTimeoutInitial, mconf.MediaTimeout) // Only enable media timeout once we send back SDP.
 		if !c.s.conf.Experimental.InboundWaitACK {
 			ackReceived = c.cc.InviteACK()
 			// Start this timer right after the Accept.
@@ -1102,8 +1103,17 @@ func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan str
 		case <-ackTimeout:
 			// Only warn, the other side still thinks the call is active, media may be flowing.
 			c.log().Warnw("Call accepted, but no ACK received", errNoACK)
-			// We don't need to wait for a full media timeout initially, we already know something is not quite right.
-			c.media.SetTimeoutForDelayedAck(min(inviteOkAckLateTimeout, c.s.conf.MediaTimeoutInitial), mediaTimeout)
+
+			// Today we seek to enforce all calls to be ACKed or dropped.
+			// Sometimes, though, we do not see ACKs for invites (e.g due to possible
+			// issues with load balancing).
+			// To accomodate this issue, instead of ending the call right here, we instead
+			// set an aggressive timeout as a softer fallback.
+			// If the issue really is a dropped ACK, media is expected to flow shortly,
+			// allowing us to accomodate this eventuality. If, however, there is no media
+			// obserrved, the call still ends quickly.
+			// Once ACKs are certain to be reliable, we will end the call here.
+			c.media.SetTimeout(min(inviteOkAckLateTimeout, c.s.conf.MediaTimeoutInitial), mediaTimeout)
 		}
 	}
 }
@@ -1200,7 +1210,7 @@ func (c *inboundCall) negotiateMedia(offerData []byte) ([]byte, error) {
 	c.mon.SDPSize(len(offerData), true)
 	c.log().Debugw("SDP offer", "sdp", string(offerData))
 
-	answerData, err := c.media.GenerateAnswer(offerData)
+	answerData, err := c.media.GenerateAnswer(offerData, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1561,7 +1571,7 @@ func (c *inboundCall) updateRemoteFromSDP(body []byte) error {
 	if mp == nil {
 		return nil
 	}
-	_, err := mp.GenerateAnswer(body)
+	_, err := mp.GenerateAnswer(body, false)
 	return err
 }
 

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -860,11 +860,6 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 
 	changeSetSummary := NewChangeSetSummary(p.negotiated, c)
 
-	// Explicitly disable renegotiation for now
-	if changeSetSummary.includes(changeSetAudioCodec | changeSetDTMF | changeSetCrypto) {
-		return SDPError{Err: ErrRenegotiationDisabled} // Results in a 400 response
-	}
-
 	if changeSetSummary.includes(changeSetLocalAddr) {
 		return errors.New("unexpected local address change")
 	}
@@ -874,6 +869,10 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 	hold := false
 
 	if changeSetSummary.shouldReconfigure() {
+		if changeSetSummary != changeSetNew { // Explicitly disable renegotiation for now
+			return SDPError{Err: ErrRenegotiationDisabled} // Results in a 400 response
+		}
+
 		p.closePipelineLocked()
 		p.port.stopDiscarding() // Needs readDeadline. Must be ahead of Reopen() and NewMediaPortPipeline()
 		p.port.Reopen()         // Allow reads from socket again

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -32,6 +32,7 @@ import (
 	msdk "github.com/livekit/media-sdk"
 	"github.com/livekit/media-sdk/rtp"
 	"github.com/livekit/media-sdk/sdp"
+	"github.com/livekit/media-sdk/srtp"
 	"github.com/livekit/mediatransportutil/pkg/rtcconfig"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/protocol/logger"
@@ -463,6 +464,14 @@ func NewMediaPortWith(log logger.Logger, mon *stats.CallMonitor, conn UDPConn, o
 		}
 		conn = c
 	}
+	var localCrypto []srtp.Profile
+	if opts.Encryption != sdp.EncryptionNone {
+		var err error
+		localCrypto, err = srtp.DefaultProfiles()
+		if err != nil {
+			return nil, err
+		}
+	}
 	p := &mediaPort{
 		log:         log,
 		opts:        opts,
@@ -475,6 +484,7 @@ func NewMediaPortWith(log logger.Logger, mon *stats.CallMonitor, conn UDPConn, o
 		stats:       opts.Stats,
 		codecs:      opts.Codecs,
 		encryption:  opts.Encryption,
+		localCrypto: localCrypto,
 	}
 	// Explicitly set sample rate. We manually create resamplers to include in latency
 	p.audioOut = msdk.NewWriteCloserSwitch[msdk.PCM16Sample](targetSampleRate)
@@ -510,6 +520,7 @@ type mediaPort struct {
 	targetSampleRate int
 	codecs           *msdk.CodecSet
 	encryption       sdp.Encryption
+	localCrypto      []srtp.Profile // our SRTP material, generated once per port
 
 	mu         sync.RWMutex
 	pipeline   *mediaPortPipeline
@@ -750,7 +761,7 @@ func (p *mediaPort) GenerateOffer() ([]byte, error) {
 		return p.offer.SDP.Marshal()
 	}
 
-	offer, err := sdp.NewOfferWith(p.codecs, p.externalIP, p.Port(), p.encryption)
+	offer, err := sdp.NewOfferWithOpts(p.codecs, p.externalIP, p.Port(), p.encryption, &srtp.Options{Profiles: p.localCrypto})
 	if err != nil {
 		return nil, err
 	}
@@ -767,12 +778,15 @@ func (p *mediaPort) GenerateAnswer(offerData []byte, activateTimeout bool) ([]by
 	if err != nil {
 		return nil, SDPError{Err: err}
 	}
-	p.reportPeerCodecs(offer.MediaDesc)
+	p.mu.Lock()
+	p.offer = offer
+	p.mu.Unlock()
 
-	answer, mc, err := offer.Answer(p.externalIP, p.Port(), p.encryption)
+	answer, mc, err := offer.AnswerWith(p.externalIP, p.Port(), p.encryption, &srtp.Options{Profiles: p.localCrypto})
 	if err != nil {
 		return nil, SDPError{Err: err}
 	}
+
 	answerData, err := answer.SDP.Marshal()
 	if err != nil {
 		return nil, err
@@ -904,8 +918,8 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 		p.pipeline = newPipeline
 
 		p.localSDP = localSDP // TODO: Move to end of function when reconfiguring is supported
+		p.reportPeerCodecs(p.offer.MediaDesc)
 	} else if changeSetSummary.includes(changeSetRemoteAddr) {
-
 		if c.Remote.Addr().IsUnspecified() {
 			// Older hold semantics: c=0.0.0.0
 			hold = true

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -761,7 +761,7 @@ func (p *mediaPort) GenerateOffer() ([]byte, error) {
 		return p.offer.SDP.Marshal()
 	}
 
-	offer, err := sdp.NewOfferWithOpts(p.codecs, p.externalIP, p.Port(), p.encryption, &srtp.Options{Profiles: p.localCrypto})
+	offer, err := sdp.NewOfferWith(p.codecs, p.externalIP, p.Port(), p.encryption, sdp.WithLocalProfiles(p.localCrypto))
 	if err != nil {
 		return nil, err
 	}
@@ -782,7 +782,7 @@ func (p *mediaPort) GenerateAnswer(offerData []byte, activateTimeout bool) ([]by
 	p.offer = offer
 	p.mu.Unlock()
 
-	answer, mc, err := offer.AnswerWith(p.externalIP, p.Port(), p.encryption, &srtp.Options{Profiles: p.localCrypto})
+	answer, mc, err := offer.Answer(p.externalIP, p.Port(), p.encryption, sdp.WithLocalProfiles(p.localCrypto))
 	if err != nil {
 		return nil, SDPError{Err: err}
 	}

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -15,6 +15,7 @@
 package sip
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"math"
@@ -29,7 +30,6 @@ import (
 	psdp "github.com/pion/sdp/v3"
 
 	msdk "github.com/livekit/media-sdk"
-	"github.com/livekit/media-sdk/dtmf"
 	"github.com/livekit/media-sdk/rtp"
 	"github.com/livekit/media-sdk/sdp"
 	"github.com/livekit/mediatransportutil/pkg/rtcconfig"
@@ -46,6 +46,8 @@ const (
 	dstChangePrintInterval     = 10 * 1000 * 1000 * 1000 // 10 seconds, in nanoseconds
 	srcChangePrintInterval     = dstChangePrintInterval
 )
+
+var ErrRenegotiationDisabled = errors.New("renegotiation is not supported")
 
 type PortStatsSnapshot struct {
 	Streams        uint64 `json:"streams"`
@@ -516,12 +518,11 @@ type mediaPort struct {
 	codecs           *msdk.CodecSet
 	encryption       sdp.Encryption
 
-	mu               sync.RWMutex
-	negotiatedCodecs *msdk.CodecSet
-	pipeline         *mediaPortPipeline
-	localSDP         []byte
-	offer            *sdp.Offer
-	audioConf        *sdp.AudioConfig
+	mu         sync.RWMutex
+	pipeline   *mediaPortPipeline
+	localSDP   []byte
+	offer      *sdp.Offer
+	negotiated *sdp.MediaConfig
 
 	audioIn  *msdk.WriteCloserSwitch[msdk.PCM16Sample] // SIP RTP -> LK PCM
 	audioOut *msdk.WriteCloserSwitch[msdk.PCM16Sample] // LK PCM -> SIP RTP
@@ -781,14 +782,7 @@ func (p *mediaPort) GenerateAnswer(offerData []byte) ([]byte, error) {
 		return p.GetLocalSDP()
 	}
 
-	codecs := p.codecs
-	p.mu.RLock()
-	if p.negotiatedCodecs != nil {
-		codecs = p.negotiatedCodecs
-	}
-	p.mu.RUnlock()
-
-	offer, err := sdp.ParseOfferWith(codecs, offerData)
+	offer, err := sdp.ParseOfferWith(p.codecs, offerData)
 	if err != nil {
 		return nil, SDPError{Err: err}
 	}
@@ -847,7 +841,10 @@ func (p *mediaPort) GetLocalSDP() ([]byte, error) {
 func (p *mediaPort) NegotiatedAudio() *sdp.AudioConfig {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
-	return p.audioConf
+	if p.negotiated == nil {
+		return nil
+	}
+	return &p.negotiated.Audio
 }
 
 // Building pipeline
@@ -868,48 +865,67 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 		return errors.New("media is already closed")
 	}
 
-	if p.pipeline != nil {
-		// This block is here to preserve compatibility with pre-refactor code.
-		// We will remove this code shortly, once the existing behavior is verified via new code.
-		if !c.Remote.Addr().IsUnspecified() { // Compat with older code
+	changeSetSummary := NewChangeSetSummary(p.negotiated, c)
+
+	// Explicitly disable renegotiation for now
+	if changeSetSummary.includes(changeSetAudioCodec | changeSetDTMF | changeSetCrypto) {
+		return SDPError{Err: ErrRenegotiationDisabled} // Results in a 400 response
+	}
+
+	if changeSetSummary.includes(changeSetLocalAddr) {
+		return errors.New("unexpected local address change")
+	}
+
+	audioToPort := p.audioOut.Swap(nil) // either nil or no-op closer
+	dtmfToPort := p.dtmfOut.Swap(nil)   // either nil or no-op closer
+	hold := false
+
+	if changeSetSummary.shouldReconfigure() {
+		p.closePipelineLocked()
+		p.port.stopDiscarding() // Needs readDeadline. Must be ahead of Reopen() and NewMediaPortPipeline()
+		p.port.Reopen()         // Allow reads from socket again
+
+		pipelineConfig := &MediaPortPipelineConfig{
+			log:       p.log,
+			opts:      p.opts,
+			mon:       p.mon,
+			stats:     p.stats,
+			onNewSSRC: p.mediaReceived.Break,
+			onPacket:  p.onNewMediaPacket,
+		}
+		newPipeline, err := NewMediaPortPipeline(
+			pipelineConfig,
+			c,
+			p.port,
+			p.audioIn,
+			&p.dtmfIn,
+			p.audioOut.SampleRate(),
+		)
+		if err != nil {
+			return err
+		}
+
+		audioToPort, dtmfToPort = newPipeline.GetConnectors() // These are not propagating Close()
+		p.pipeline = newPipeline
+
+		p.enableTimeoutWithDefaults()
+		p.localSDP = localSDP // TODO: Move to end of function when reconfiguring is supported
+	} else if changeSetSummary.includes(changeSetRemoteAddr) {
+
+		if c.Remote.Addr().IsUnspecified() {
+			// Older hold semantics: c=0.0.0.0
+			hold = true
+		} else {
 			p.port.SetDst(netip.AddrPortFrom(c.Remote.Addr(), c.Remote.Port()))
 		}
-		return nil
 	}
-
-	// TODO: Avoid reconfiguring if mc unchanged; maybe only adjust direction
-
-	p.closePipelineLocked()
-	p.port.stopDiscarding() // Needs readDeadline. Must be ahead of Reopen() and NewMediaPortPipeline()
-	p.port.Reopen()         // Allow reads from socket again
-
-	pipelineConfig := &MediaPortPipelineConfig{
-		log:       p.log,
-		opts:      p.opts,
-		mon:       p.mon,
-		stats:     p.stats,
-		onNewSSRC: p.mediaReceived.Break,
-		onPacket:  p.onNewMediaPacket,
-	}
-	newPipeline, err := NewMediaPortPipeline(
-		pipelineConfig,
-		c,
-		p.port,
-		p.audioIn,
-		&p.dtmfIn,
-		p.audioOut.SampleRate(),
-	)
-	if err != nil {
-		return err
-	}
-
-	audioToPort, dtmfToPort := newPipeline.GetConnectors() // These are not propagating Close()
-	p.pipeline = newPipeline
-
-	if c.PeerDirection == psdp.DirectionSendOnly || c.Remote.Addr().IsUnspecified() {
-		// Older hold semantics: c=0.0.0.0; Newer hold semantics: a=sendonly
+	if changeSetSummary.includes(changeSetPeerDirection) {
+		// Newer hold semantics: a=sendonly
 		// TODO: Support a=recvonly/inactive; requires toggling media timeout;
 		//		maybe gate these on timers being active on the session to prevent dud calls
+		hold = c.PeerDirection == psdp.DirectionSendOnly
+	}
+	if false && hold { // Disabled in current code
 		audioToPort = nil
 		dtmfToPort = nil
 		zero := netip.IPv4Unspecified()
@@ -920,26 +936,72 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 		p.log.Infow("peer requested hold", "direction", c.PeerDirection.String(), "remote", c.Remote.String())
 	}
 
-	if old := p.audioOut.Swap(audioToPort); old != nil {
-		_ = old.Close()
-	}
-	if old := p.dtmfOut.Swap(dtmfToPort); old != nil {
-		_ = old.Close()
-	}
+	p.audioOut.Swap(audioToPort) // guaranteed old nil
+	p.dtmfOut.Swap(dtmfToPort)   // guaranteed old nil
+
 	p.offer = nil // Pipeline build done, can now proceed to offer anew
-	p.localSDP = localSDP
-	p.audioConf = &c.Audio
-	negotiated := msdk.NewCodecSet()
-	negotiated.SetEnabled(c.Audio.Codec.Info().SDPName, true)
-	if c.Audio.DTMFType != 0 {
-		negotiated.SetEnabled(dtmf.SDPNameAndRate, true)
-	}
-	p.negotiatedCodecs = negotiated
-	p.enableTimeoutWithDefaults()
+	p.negotiated = c
 	return nil
 }
 
 func (p *mediaPort) onNewMediaPacket() {
 	p.packetCount.Add(1)
 	p.lastPacketTime.Store(time.Now().UnixNano())
+}
+
+type changeSetSummary uint
+
+const (
+	changeSetNew changeSetSummary = 1 << iota // 1 << 0 = 1
+	changeSetAudioCodec
+	changeSetDTMF
+	changeSetCrypto
+	changeSetLocalAddr
+	changeSetRemoteAddr
+	changeSetPeerDirection
+)
+
+func NewChangeSetSummary(current, new *sdp.MediaConfig) changeSetSummary {
+	if current == nil {
+		return changeSetNew
+	}
+	var changeSetSummary changeSetSummary
+	if current.Audio.Codec.Info().SDPName != new.Audio.Codec.Info().SDPName {
+		changeSetSummary |= changeSetAudioCodec
+	}
+	if current.Audio.DTMFType != new.Audio.DTMFType || current.Audio.Type != new.Audio.Type {
+		changeSetSummary |= changeSetDTMF
+	}
+	a, b := current.Crypto, new.Crypto
+	if a == nil || b == nil {
+		if a != b {
+			changeSetSummary |= changeSetCrypto
+		}
+	} else { // Prodile exists on both
+		if a.Profile != b.Profile ||
+			!bytes.Equal(a.Keys.LocalMasterKey, b.Keys.LocalMasterKey) ||
+			!bytes.Equal(a.Keys.LocalMasterSalt, b.Keys.LocalMasterSalt) ||
+			!bytes.Equal(a.Keys.RemoteMasterKey, b.Keys.RemoteMasterKey) ||
+			!bytes.Equal(a.Keys.RemoteMasterSalt, b.Keys.RemoteMasterSalt) {
+			changeSetSummary |= changeSetCrypto
+		}
+	}
+	if current.Local != new.Local {
+		changeSetSummary |= changeSetLocalAddr
+	}
+	if current.Remote != new.Remote {
+		changeSetSummary |= changeSetRemoteAddr
+	}
+	if current.PeerDirection != new.PeerDirection {
+		changeSetSummary |= changeSetPeerDirection
+	}
+	return changeSetSummary
+}
+
+func (c changeSetSummary) shouldReconfigure() bool {
+	return c&(changeSetNew|changeSetAudioCodec|changeSetDTMF|changeSetCrypto) != 0
+}
+
+func (c changeSetSummary) includes(feature changeSetSummary) bool {
+	return c&feature != 0
 }

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -885,6 +885,30 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 
 	hold := false
 
+	if changeSetSummary.includes(changeSetRemoteAddr) {
+		if c.Remote.Addr().IsUnspecified() {
+			// Older hold semantics: c=0.0.0.0
+			hold = true
+		} else {
+			p.port.SetDst(netip.AddrPortFrom(c.Remote.Addr(), c.Remote.Port()))
+		}
+	}
+	if changeSetSummary.includes(changeSetPeerDirection) {
+		// Newer hold semantics: a=sendonly
+		// TODO: Support a=recvonly/inactive; requires toggling media timeout;
+		//		maybe gate these on timers being active on the session to prevent dud calls
+		hold = c.PeerDirection == psdp.DirectionSendOnly
+	}
+	if false && hold { // Disabled in current code
+		audioToPort = nil
+		dtmfToPort = nil
+		zero := netip.IPv4Unspecified()
+		if !c.Remote.Addr().Is4() {
+			zero = netip.IPv6Unspecified()
+		}
+		p.port.SetDst(netip.AddrPortFrom(zero, c.Remote.Port()))
+		p.log.Infow("peer requested hold", "direction", c.PeerDirection.String(), "remote", c.Remote.String())
+	}
 	if changeSetSummary.shouldReconfigure() {
 		if changeSetSummary != changeSetNew { // Explicitly disable renegotiation for now
 			return SDPError{Err: ErrRenegotiationDisabled} // Results in a 400 response
@@ -919,31 +943,7 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 
 		p.localSDP = localSDP // TODO: Move to end of function when reconfiguring is supported
 		p.reportPeerCodecs(p.offer.MediaDesc)
-	} else if changeSetSummary.includes(changeSetRemoteAddr) {
-		if c.Remote.Addr().IsUnspecified() {
-			// Older hold semantics: c=0.0.0.0
-			hold = true
-		} else {
-			p.port.SetDst(netip.AddrPortFrom(c.Remote.Addr(), c.Remote.Port()))
-		}
 	}
-	if changeSetSummary.includes(changeSetPeerDirection) {
-		// Newer hold semantics: a=sendonly
-		// TODO: Support a=recvonly/inactive; requires toggling media timeout;
-		//		maybe gate these on timers being active on the session to prevent dud calls
-		hold = c.PeerDirection == psdp.DirectionSendOnly
-	}
-	if false && hold { // Disabled in current code
-		audioToPort = nil
-		dtmfToPort = nil
-		zero := netip.IPv4Unspecified()
-		if !c.Remote.Addr().Is4() {
-			zero = netip.IPv6Unspecified()
-		}
-		p.port.SetDst(netip.AddrPortFrom(zero, c.Remote.Port()))
-		p.log.Infow("peer requested hold", "direction", c.PeerDirection.String(), "remote", c.Remote.String())
-	}
-
 	p.offer = nil // Pipeline build done, can now proceed to offer anew
 	p.negotiated = c
 	return nil
@@ -971,10 +971,10 @@ func NewChangeSetSummary(current, new *sdp.MediaConfig) changeSetSummary {
 		return changeSetNew
 	}
 	var changeSetSummary changeSetSummary
-	if current.Audio.Codec.Info().SDPName != new.Audio.Codec.Info().SDPName {
+	if current.Audio.Codec.Info().SDPName != new.Audio.Codec.Info().SDPName || current.Audio.Type != new.Audio.Type {
 		changeSetSummary |= changeSetAudioCodec
 	}
-	if current.Audio.DTMFType != new.Audio.DTMFType || current.Audio.Type != new.Audio.Type {
+	if current.Audio.DTMFType != new.Audio.DTMFType {
 		changeSetSummary |= changeSetDTMF
 	}
 	a, b := current.Crypto, new.Crypto

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -536,7 +536,7 @@ func (p *mediaPort) SetTimeout(initial, general time.Duration) {
 	p.timeoutInitial.Store(&initial)
 	p.timeoutGeneral.Store(&general)
 	now := time.Now()
-	p.timeoutStart.CompareAndSwap(nil, &now) // Don't re-arm if already armed
+	p.timeoutStart.Store(&now)
 	p.log.Debugw("media timeout enabled",
 		"packets", p.packetCount.Load(),
 		"initial", initial,
@@ -865,7 +865,10 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 	}
 
 	audioToPort := p.audioOut.Swap(nil) // either nil or no-op closer
-	dtmfToPort := p.dtmfOut.Swap(nil)   // either nil or no-op closer
+	defer func() { p.audioOut.Swap(audioToPort) }()
+	dtmfToPort := p.dtmfOut.Swap(nil) // either nil or no-op closer
+	defer func() { p.dtmfOut.Swap(dtmfToPort) }()
+
 	hold := false
 
 	if changeSetSummary.shouldReconfigure() {
@@ -926,9 +929,6 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 		p.port.SetDst(netip.AddrPortFrom(zero, c.Remote.Port()))
 		p.log.Infow("peer requested hold", "direction", c.PeerDirection.String(), "remote", c.Remote.String())
 	}
-
-	p.audioOut.Swap(audioToPort) // guaranteed old nil
-	p.dtmfOut.Swap(dtmfToPort)   // guaranteed old nil
 
 	p.offer = nil // Pipeline build done, can now proceed to offer anew
 	p.negotiated = c

--- a/pkg/sip/media_port.go
+++ b/pkg/sip/media_port.go
@@ -415,9 +415,12 @@ type MediaPort interface {
 	GenerateOffer() ([]byte, error)
 
 	// GenerateAnswer returns an encoded SDP answer for the given offer.
+	// activateTimeout - If set to true, resets media timeout to defaults,
+	//		starting from time of function call. This is designed to
+	//		be set to false when not immediately sending the answer back.
 	//
 	// SIDE EFFECT: May cause a rebuild of the pipeline.
-	GenerateAnswer(offer []byte) ([]byte, error)
+	GenerateAnswer(offer []byte, activateTimeout bool) ([]byte, error)
 
 	// ProcessAnswer processes an encoded SDP answer from the remote client. Returns an
 	// error if the answer is invalid, the offer has not yet been generated, or
@@ -436,18 +439,8 @@ type MediaPort interface {
 
 	// SetTimeout resets the media timeout with the given values.
 	//
-	// NOTE: This method will be removed at some point in the future and is only
-	// used by one caller. Do not call this method: specify media timeout
-	// settings when constructing a MediaPort.
-	//
-	// We would like to enforce the fact that all invites must be ACKed.
-	// Sometimes, though, for whatever reason, we do not see ACKs for invites
-	// (e.g due to possible issues with load balancing). In such cases where
-	// we require an invite to be ACKed (guarded by the `InboundWaitACK`
-	// setting), if we don't see the ACK within some amount of time, then we
-	// restrict the timeout with this method so that the call might end earlier
-	// than if the timeout were never shortened.
-	SetTimeoutForDelayedAck(initial, general time.Duration)
+	// NOTE: This method is likely to go through additional changes.
+	SetTimeout(initial, general time.Duration)
 
 	Received() <-chan struct{}
 	MediaTimeout() <-chan struct{}
@@ -530,41 +523,29 @@ type mediaPort struct {
 	dtmfOut  msdk.WriteCloserSwitch[*livekit.SipDTMF]  // LK DTMF -> SIP DTMF
 }
 
-func (p *mediaPort) kickTimeoutLoop() {
-	select {
-	case p.timeoutKick <- struct{}{}:
-	default: // already pending
-	}
-}
-
-func (p *mediaPort) enableTimeout(initial, general time.Duration) {
+func (p *mediaPort) SetTimeout(initial, general time.Duration) {
 	if initial <= 0 || general <= 0 {
-		p.log.Warnw("attempting to set zero media timeout", nil, "initial", initial, "timeout", general)
+		p.log.Debugw("attempting to set zero media timeout", "initial", initial, "timeout", general, "fallbackInitial", p.opts.MediaTimeoutInitial, "fallbackTimeout", p.opts.MediaTimeout)
 		if initial <= 0 {
-			initial = defaultMediaTimeoutInitial
+			initial = p.opts.MediaTimeoutInitial
 		}
 		if general <= 0 {
-			general = defaultMediaTimeout
+			general = p.opts.MediaTimeout
 		}
 	}
 	p.timeoutInitial.Store(&initial)
 	p.timeoutGeneral.Store(&general)
 	now := time.Now()
-	p.timeoutStart.Store(&now)
+	p.timeoutStart.CompareAndSwap(nil, &now) // Don't re-arm if already armed
 	p.log.Debugw("media timeout enabled",
 		"packets", p.packetCount.Load(),
 		"initial", initial,
 		"timeout", general,
 	)
-	p.kickTimeoutLoop()
-}
-
-func (p *mediaPort) enableTimeoutWithDefaults() {
-	p.enableTimeout(p.opts.MediaTimeoutInitial, p.opts.MediaTimeout)
-}
-
-func (p *mediaPort) SetTimeoutForDelayedAck(initial, general time.Duration) {
-	p.enableTimeout(initial, general)
+	select {
+	case p.timeoutKick <- struct{}{}:
+	default: // already pending
+	}
 }
 
 func (p *mediaPort) mediaTimeoutLoop() {
@@ -777,7 +758,7 @@ func (p *mediaPort) GenerateOffer() ([]byte, error) {
 	return offer.SDP.Marshal()
 }
 
-func (p *mediaPort) GenerateAnswer(offerData []byte) ([]byte, error) {
+func (p *mediaPort) GenerateAnswer(offerData []byte, activateTimeout bool) ([]byte, error) {
 	if len(offerData) == 0 {
 		return p.GetLocalSDP()
 	}
@@ -796,7 +777,14 @@ func (p *mediaPort) GenerateAnswer(offerData []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return answerData, p.configure(mc, answerData)
+	err = p.configure(mc, answerData)
+	if err != nil {
+		return nil, err
+	}
+	if activateTimeout {
+		p.SetTimeout(p.opts.MediaTimeoutInitial, p.opts.MediaTimeout)
+	}
+	return answerData, nil
 }
 
 func (p *mediaPort) ProcessAnswer(answerData []byte) error {
@@ -826,7 +814,12 @@ func (p *mediaPort) ProcessAnswer(answerData []byte) error {
 		return err
 	}
 
-	return p.configure(mc, localSDPBytes)
+	err = p.configure(mc, localSDPBytes)
+	if err != nil {
+		return err
+	}
+	p.SetTimeout(p.opts.MediaTimeoutInitial, p.opts.MediaTimeout)
+	return nil
 }
 
 func (p *mediaPort) GetLocalSDP() ([]byte, error) {
@@ -908,7 +901,6 @@ func (p *mediaPort) configure(c *sdp.MediaConfig, localSDP []byte) error {
 		audioToPort, dtmfToPort = newPipeline.GetConnectors() // These are not propagating Close()
 		p.pipeline = newPipeline
 
-		p.enableTimeoutWithDefaults()
 		p.localSDP = localSDP // TODO: Move to end of function when reconfiguring is supported
 	} else if changeSetSummary.includes(changeSetRemoteAddr) {
 

--- a/pkg/sip/media_port_negotiation_test.go
+++ b/pkg/sip/media_port_negotiation_test.go
@@ -147,7 +147,7 @@ func TestMediaPortCodecSet(t *testing.T) {
 		// Peer offers both, only PCMA is enabled here.
 		offer := sdpWithMedia("m=audio 5004 RTP/AVP 0 8",
 			"a=rtpmap:0 PCMU/8000", "a=rtpmap:8 PCMA/8000")
-		answerData, err := m.GenerateAnswer(offer)
+		answerData, err := m.GenerateAnswer(offer, true)
 		require.NoError(t, err)
 		assert.Equal(t, g711.ALawSDPNameAndRate, answerCodec(t, answerData))
 	})
@@ -156,7 +156,7 @@ func TestMediaPortCodecSet(t *testing.T) {
 		m := newLocked(t, g711.ALawSDPNameAndRate)
 
 		offer := sdpWithMedia("m=audio 5004 RTP/AVP 0", "a=rtpmap:0 PCMU/8000")
-		_, err := m.GenerateAnswer(offer)
+		_, err := m.GenerateAnswer(offer, true)
 		require.ErrorIs(t, err, sdp.ErrNoCommonMedia)
 	})
 }
@@ -172,16 +172,16 @@ func TestMediaPortRejectsDifferentCodecOffer(t *testing.T) {
 	sdpB := sdpWithMedia("m=audio 5004 RTP/AVP 9", "a=rtpmap:9 G722/8000")
 
 	// Offer codec A
-	answer, err := m.GenerateAnswer(sdpA)
+	answer, err := m.GenerateAnswer(sdpA, true)
 	require.NoError(t, err)
 	require.Equal(t, g711.ULawSDPNameAndRate, answerCodec(t, answer))
 
 	// Attempt to offer only codec B, expect failure
-	answer, err = m.GenerateAnswer(sdpB)
+	answer, err = m.GenerateAnswer(sdpB, true)
 	require.ErrorIs(t, err, ErrRenegotiationDisabled)
 
 	// Offer codec A again, expect success
-	answer, err = m.GenerateAnswer(sdpA)
+	answer, err = m.GenerateAnswer(sdpA, true)
 	require.NoError(t, err)
 	require.Equal(t, g711.ULawSDPNameAndRate, answerCodec(t, answer))
 }
@@ -283,7 +283,7 @@ func TestMediaPortHold(t *testing.T) {
 			// m2 re-INVITEs with the hold form of its offer.
 			base, err := m2.GenerateOffer()
 			require.NoError(t, err)
-			_, err = m1.GenerateAnswer([]byte(tc.hold(t, string(base))))
+			_, err = m1.GenerateAnswer([]byte(tc.hold(t, string(base))), true)
 			require.NoError(t, err)
 
 			// m1 no longer sends: no destination to write to, and the room-facing
@@ -304,7 +304,7 @@ func TestMediaPortHold(t *testing.T) {
 			requireAudioFlows(t, m2, recv1)
 
 			// Resume with the original offer.
-			_, err = m1.GenerateAnswer(base)
+			_, err = m1.GenerateAnswer(base, true)
 			require.NoError(t, err)
 
 			dst = m1.port.dst.Load()

--- a/pkg/sip/media_port_negotiation_test.go
+++ b/pkg/sip/media_port_negotiation_test.go
@@ -178,7 +178,7 @@ func TestMediaPortRejectsDifferentCodecOffer(t *testing.T) {
 
 	// Attempt to offer only codec B, expect failure
 	answer, err = m.GenerateAnswer(sdpB)
-	require.ErrorIs(t, err, sdp.ErrNoCommonMedia)
+	require.ErrorIs(t, err, ErrRenegotiationDisabled)
 
 	// Offer codec A again, expect success
 	answer, err = m.GenerateAnswer(sdpA)

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -208,7 +208,12 @@ func newTestPort(t testing.TB, log logger.Logger, conn UDPConn, opts *MediaOptio
 
 func offerAt(t testing.TB, addr netip.AddrPort) []byte {
 	t.Helper()
-	offer, err := sdp.NewOfferWith(defaultCodecs, addr.Addr(), int(addr.Port()), sdp.EncryptionNone)
+	return offerAtEnc(t, addr, sdp.EncryptionNone)
+}
+
+func offerAtEnc(t testing.TB, addr netip.AddrPort, enc sdp.Encryption) []byte {
+	t.Helper()
+	offer, err := sdp.NewOfferWith(defaultCodecs, addr.Addr(), int(addr.Port()), enc)
 	require.NoError(t, err)
 	data, err := offer.SDP.Marshal()
 	require.NoError(t, err)
@@ -243,6 +248,43 @@ func TestMediaPortUpdateRemote(t *testing.T) {
 	_, err = mp.GenerateAnswer(offerAt(t, addr), true)
 	require.NoError(t, err)
 	require.Equal(t, addr, mp.RemoteAddr(), "re-INVITE offer should update RemoteAddr")
+}
+
+// Re-INVITE with the original offer SDP and crypto material must result in
+// re-use of already-negotiated keys.
+func TestMediaPortReinviteSameCrypto(t *testing.T) {
+	c1, _ := newUDPPipe()
+	mp := newTestPort(t, logger.NewTestLogger(t), c1, &MediaOptions{
+		IP:         netip.MustParseAddr("127.0.0.1"),
+		Encryption: sdp.EncryptionRequire,
+	}, RoomSampleRate)
+
+	addr := netip.MustParseAddrPort("9.8.7.6:12345")
+	offer := offerAtEnc(t, addr, sdp.EncryptionRequire)
+
+	_, err := mp.GenerateAnswer(offer, true)
+	require.NoError(t, err)
+	require.Equal(t, addr, mp.RemoteAddr())
+
+	require.NotNil(t, mp.negotiated)
+	require.NotNil(t, mp.negotiated.Crypto)
+	localKey := slices.Clone(mp.negotiated.Crypto.Keys.LocalMasterKey)
+	localSalt := slices.Clone(mp.negotiated.Crypto.Keys.LocalMasterSalt)
+	require.NotEmpty(t, localKey)
+	require.NotEmpty(t, localSalt)
+	localSDP, err := mp.GetLocalSDP()
+	require.NoError(t, err)
+	require.NotEmpty(t, localSDP)
+
+	// Same offer bytes: NewOfferWith would generate a new peer key.
+	_, err = mp.GenerateAnswer(offer, true)
+	require.NoError(t, err, "re-INVITE with the same offer must be accepted")
+	require.Equal(t, addr, mp.RemoteAddr(), "same offer must not change dest")
+	require.Equal(t, localKey, mp.negotiated.Crypto.Keys.LocalMasterKey, "local master key must not change")
+	require.Equal(t, localSalt, mp.negotiated.Crypto.Keys.LocalMasterSalt, "local master salt must not change")
+	gotSDP, err := mp.GetLocalSDP()
+	require.NoError(t, err)
+	require.Equal(t, localSDP, gotSDP, "local SDP (including a=crypto) must not change")
 }
 
 // negotiate runs a full offer/answer between two ports, m1 offering, and returns the answer.

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -29,6 +29,7 @@ import (
 
 	msdk "github.com/livekit/media-sdk"
 	"github.com/livekit/media-sdk/sdp"
+	"github.com/livekit/media-sdk/srtp"
 	"github.com/livekit/mediatransportutil/pkg/rtcconfig"
 	"github.com/livekit/protocol/logger"
 
@@ -285,6 +286,40 @@ func TestMediaPortReinviteSameCrypto(t *testing.T) {
 	gotSDP, err := mp.GetLocalSDP()
 	require.NoError(t, err)
 	require.Equal(t, localSDP, gotSDP, "local SDP (including a=crypto) must not change")
+}
+
+func TestMediaPortReofferSameCrypto(t *testing.T) {
+	c1, _ := newUDPPipe()
+	mp := newTestPort(t, logger.NewTestLogger(t), c1, &MediaOptions{
+		IP:         netip.MustParseAddr("127.0.0.1"),
+		Encryption: sdp.EncryptionRequire,
+	}, RoomSampleRate)
+
+	newOffer := func(t testing.TB, mp *mediaPort, localCrypto []srtp.Profile) (*sdp.Offer, *sdp.MediaConfig) {
+		t.Helper()
+		addr := netip.MustParseAddrPort("9.8.7.6:12345")
+		offerData, err := mp.GenerateOffer()
+		require.NoError(t, err)
+		offer, err := sdp.ParseOfferWith(defaultCodecs, offerData)
+		require.NoError(t, err)
+		answer, mc, err := offer.Answer(addr.Addr(), int(addr.Port()), sdp.EncryptionRequire, sdp.WithLocalProfiles(localCrypto))
+		require.NoError(t, err)
+		answerData, err := answer.SDP.Marshal()
+		require.NoError(t, err)
+		err = mp.ProcessAnswer(answerData)
+		require.NoError(t, err)
+		require.Nil(t, mp.offer)
+		return offer, mc
+	}
+	localCrypto, err := srtp.DefaultProfiles()
+	require.NoError(t, err)
+	offer1, mc1 := newOffer(t, mp, localCrypto)
+	offer2, mc2 := newOffer(t, mp, localCrypto)
+
+	// Offers must not regenerate keys
+	require.Equal(t, offer1.CryptoProfiles, offer2.CryptoProfiles, "crypto profiles must not change")
+	require.Equal(t, mc1.Crypto.Keys.RemoteMasterKey, mc2.Crypto.Keys.RemoteMasterKey, "remote master key must not change")
+	require.Equal(t, mc1.Crypto.Keys.RemoteMasterSalt, mc2.Crypto.Keys.RemoteMasterSalt, "remote master salt must not change")
 }
 
 // negotiate runs a full offer/answer between two ports, m1 offering, and returns the answer.

--- a/pkg/sip/media_port_test.go
+++ b/pkg/sip/media_port_test.go
@@ -224,23 +224,23 @@ func TestMediaPortUpdateRemote(t *testing.T) {
 	require.False(t, mp.RemoteAddr().IsValid(), "RemoteAddr should be invalid before any offer")
 
 	addr := netip.MustParseAddrPort("9.8.7.6:12345")
-	_, err := mp.GenerateAnswer(offerAt(t, addr))
+	_, err := mp.GenerateAnswer(offerAt(t, addr), true)
 	require.NoError(t, err)
 	require.Equal(t, addr, mp.RemoteAddr(), "GenerateAnswer should set RemoteAddr from the offer")
 
 	// Body-less re-INVITE: empty offer returns the local SDP and must not change dest.
-	_, err = mp.GenerateAnswer(nil)
+	_, err = mp.GenerateAnswer(nil, true)
 	require.NoError(t, err)
 	require.Equal(t, addr, mp.RemoteAddr(), "empty offer should not change RemoteAddr")
 
 	// Hold form c=0.0.0.0 must not clobber dest once media is established.
-	_, err = mp.GenerateAnswer(offerAt(t, netip.MustParseAddrPort("0.0.0.0:12345")))
+	_, err = mp.GenerateAnswer(offerAt(t, netip.MustParseAddrPort("0.0.0.0:12345")), true)
 	require.NoError(t, err)
 	require.Equal(t, addr, mp.RemoteAddr(), "offer with unspecified addr should not change RemoteAddr")
 
 	// successful re-INVITE update
 	addr = netip.MustParseAddrPort("10.10.10.10:54321")
-	_, err = mp.GenerateAnswer(offerAt(t, addr))
+	_, err = mp.GenerateAnswer(offerAt(t, addr), true)
 	require.NoError(t, err)
 	require.Equal(t, addr, mp.RemoteAddr(), "re-INVITE offer should update RemoteAddr")
 }
@@ -251,7 +251,7 @@ func negotiate(t testing.TB, m1, m2 *mediaPort) []byte {
 	offerData, err := m1.GenerateOffer()
 	require.NoError(t, err)
 
-	answerData, err := m2.GenerateAnswer(offerData)
+	answerData, err := m2.GenerateAnswer(offerData, true)
 	require.NoError(t, err)
 
 	require.NoError(t, m1.ProcessAnswer(answerData))
@@ -399,7 +399,7 @@ func TestMediaTimeout(t *testing.T) {
 		// the general timeout applies relative to the last received RTP packet.
 		// Last packet arrived at most timeout/2 ago, so the timeout should fire
 		// within ~timeout from now, well before initial would elapse.
-		m1.SetTimeoutForDelayedAck(initial, timeout)
+		m1.SetTimeout(initial, timeout)
 
 		select {
 		case <-time.After(timeout + dt):
@@ -418,7 +418,7 @@ func TestMediaTimeout(t *testing.T) {
 		// port has never seen an RTP packet, the new initial window applies from
 		// the moment of the SetTimeout call.
 		time.Sleep(initial / 2)
-		m1.SetTimeoutForDelayedAck(initial, timeout)
+		m1.SetTimeout(initial, timeout)
 
 		targ := time.Now().Add(initial)
 		select {
@@ -591,7 +591,7 @@ func TestSetOfferReportsCodecsBeforeFailing(t *testing.T) {
 	pcmuBefore := gatherCounter(t, offeredMetric, pcmu)
 
 	offer := sdpWithMedia("m=audio 5004 RTP/AVP 96", "a=rtpmap:96 SPEEX/16000")
-	_, err := mp.GenerateAnswer(offer)
+	_, err := mp.GenerateAnswer(offer, true)
 	require.ErrorIs(t, err, sdp.ErrNoCommonMedia)
 
 	// Codecs that are not part of the internal set are classified as "other"
@@ -613,7 +613,7 @@ func TestSetOfferReportsCodecsPerProvider(t *testing.T) {
 
 	offer := sdpWithMedia("m=audio 5004 RTP/AVP 0 9",
 		"a=rtpmap:0 PCMU/8000", "a=rtpmap:9 G722/8000")
-	_, err := mp.GenerateAnswer(offer)
+	_, err := mp.GenerateAnswer(offer, true)
 	require.NoError(t, err)
 
 	require.Equal(t, parsedBefore+1, gatherCounter(t, parsedMetric, parsed))
@@ -630,7 +630,7 @@ func TestSetOfferReportsUnknownProvider(t *testing.T) {
 	before := gatherCounter(t, parsedMetric, parsed)
 
 	offer := sdpWithMedia("m=audio 5004 RTP/AVP 0", "a=rtpmap:0 PCMU/8000")
-	_, err := mp.GenerateAnswer(offer)
+	_, err := mp.GenerateAnswer(offer, true)
 	require.NoError(t, err)
 
 	require.Equal(t, before+1, gatherCounter(t, parsedMetric, parsed))

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -537,7 +537,7 @@ func (c *outboundCall) updateRemoteFromSDP(body []byte) error {
 	if mp == nil {
 		return nil
 	}
-	_, err := mp.GenerateAnswer(body)
+	_, err := mp.GenerateAnswer(body, false)
 	return err
 }
 

--- a/pkg/sip/service_test.go
+++ b/pkg/sip/service_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
-	"net/netip"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -49,11 +48,29 @@ func getResponseOrFail(t *testing.T, tx sip.ClientTransaction) *sip.Response {
 
 	return nil
 }
+func getResponseOrFailTimeout(t *testing.T, ctx context.Context, tx sip.ClientTransaction) *sip.Response {
+	var ctxDone <-chan struct{} = nil
+	if ctx != nil {
+		ctxDone = ctx.Done()
+	}
+	select {
+	case <-t.Context().Done():
+		t.Fatal("Test context cancelled")
+	case <-ctxDone:
+		t.Fatal("Context cancelled")
+	case <-tx.Done():
+		t.Fatal("Transaction failed to complete")
+	case res := <-tx.Responses():
+		return res
+	}
 
-func getFinalResponseOrFail(t *testing.T, tx sip.ClientTransaction, req *sip.Request) *sip.Response {
+	return nil
+}
+
+func getFinalResponseOrFail(t *testing.T, ctx context.Context, tx sip.ClientTransaction) *sip.Response {
 	var res *sip.Response
 	for {
-		res = getResponseOrFail(t, tx)
+		res = getResponseOrFailTimeout(t, ctx, tx)
 		if res.StatusCode >= 200 {
 			break
 		}
@@ -324,7 +341,7 @@ func TestService_RejectedInviteCacheReplay(t *testing.T) {
 		tx, err := client.TransactionRequest(req)
 		require.NoError(t, err)
 		t.Cleanup(tx.Terminate)
-		return getFinalResponseOrFail(t, tx, req)
+		return getFinalResponseOrFail(t, nil, tx)
 	}
 
 	// First INVITE: full handler invocation, 404 from DispatchNoRuleReject.
@@ -898,46 +915,32 @@ func TestCANCELSendsBothResponses(t *testing.T) {
 	)
 
 	st := NewServiceTest(t, &serviceTestConfig{GetRoom: newTestRoomConfig(&testRoomConfig{ringForever: true})})
-	loopback := netip.MustParseAddr("127.0.0.1")
-	sipServerAddress := st.Address()
 
-	// Create SIP client using sipgo
-	sipUserAgent, err := sipgo.NewUA(
-		sipgo.WithUserAgent(fromUser),
-	)
+	call := newTestCall(st.TestUA, false)
+	req, localSDP, err := call.Invite(nil)
 	require.NoError(t, err)
+	call.SetLocalSDP(localSDP)
 
-	sipClient, err := sipgo.NewClient(sipUserAgent)
-	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
+	defer cancel()
 
-	// Create SDP offer
-	offer, err := sdp.NewOfferWith(defaultCodecs, loopback, 0xB0B, sdp.EncryptionNone)
+	inviteTx, err := st.TestUA.Client.TransactionRequest(req)
 	require.NoError(t, err)
-	offerData, err := offer.SDP.Marshal()
-	require.NoError(t, err)
-
-	// Create INVITE request
-	inviteRecipient := sip.Uri{User: toUser, Host: sipServerAddress}
-	inviteRequest := sip.NewRequest(sip.INVITE, inviteRecipient)
-	inviteRequest.SetDestination(sipServerAddress)
-	inviteRequest.SetBody(offerData)
-	inviteRequest.AppendHeader(sip.NewHeader("Content-Type", "application/sdp"))
-
-	// Send INVITE
-	tx, err := sipClient.TransactionRequest(inviteRequest)
-	require.NoError(t, err)
-	t.Cleanup(tx.Terminate)
+	defer inviteTx.Terminate()
 
 	// Wait for 100 Trying
-	res100 := getResponseOrFail(t, tx)
+	res100 := getResponseOrFailTimeout(t, ctx, inviteTx)
 	require.Equal(t, sip.StatusCode(100), res100.StatusCode, "Should receive 100 Trying")
 
 	// Wait for 180 Ringing (call is now ringing)
-	res180 := getResponseOrFail(t, tx)
+	res180 := getResponseOrFailTimeout(t, ctx, inviteTx)
 	require.Equal(t, sip.StatusCode(180), res180.StatusCode, "Should receive 180 Ringing")
+	remoteTag, ok := res180.To().Params.Get("tag")
+	require.True(t, ok, "remote tag should be present")
+	call.SetRemoteTag(LocalTag(remoteTag))
 
 	// Now send CANCEL
-	err = tx.Cancel()
+	err = inviteTx.Cancel()
 	require.NoError(t, err, "Should be able to send CANCEL")
 
 	// On-the-wire there should be two responses after CANCEL:
@@ -948,51 +951,11 @@ func TestCANCELSendsBothResponses(t *testing.T) {
 	// Sipgo treats both INVITE and CANCEL as the same transaction, and has special handling
 	// to swallow the 200 OK response to CANCEL, so it can't look like the INVITE got the 200.
 
-	// Collect responses until we get the final 487 or transaction completes
-	var responses []*sip.Response
-
-	// Wait for responses with a timeout
-	timeout := time.After(time.Second)
-
-	// Collect responses until we get 487 or timeout
-	for {
-		select {
-		case res := <-tx.Responses():
-			responses = append(responses, res)
-			cseq := res.CSeq()
-
-			// Debug: log all responses to understand what we're receiving
-			cseqMethod := "nil"
-			if cseq != nil {
-				cseqMethod = string(cseq.MethodName)
-			}
-			t.Logf("Received response: StatusCode=%d, CSeq method=%s", res.StatusCode, cseqMethod)
-
-			if res.StatusCode < 200 {
-				continue
-			}
-			require.Equal(t, sip.StatusCode(487), res.StatusCode, "Should have received 487 Request Terminated response to INVITE when CANCEL is sent")
-			require.NotNil(t, cseq, "487 response should have CSeq header")
-			require.Equal(t, sip.INVITE, cseq.MethodName, "487 response should be for INVITE method")
-			return // Success!
-
-		case <-tx.Done():
-			t.Fatal("Transaction done without receiving expected 487 response")
-
-		case <-timeout:
-			// Log all received responses for debugging
-			t.Logf("Timeout after receiving %d responses", len(responses))
-			for i, res := range responses {
-				cseq := res.CSeq()
-				cseqMethod := "nil"
-				if cseq != nil {
-					cseqMethod = string(cseq.MethodName)
-				}
-				t.Logf("  Response %d: StatusCode=%d, CSeq method=%s", i+1, res.StatusCode, cseqMethod)
-			}
-			t.Fatal("Timeout waiting for 487 Request Terminated response after CANCEL")
-		}
-	}
+	res := getFinalResponseOrFail(t, ctx, inviteTx)
+	require.Equal(t, sip.StatusCode(487), res.StatusCode, "Should have received 487 Request Terminated response to INVITE when CANCEL is sent")
+	cseq := res.CSeq()
+	require.NotNil(t, cseq, "487 response should have CSeq header")
+	require.Equal(t, sip.INVITE, cseq.MethodName, "487 response should be for INVITE method")
 }
 
 // TestSameCallIDForAuthFlow verifies that the same LiveKit call ID is assigned to both

--- a/pkg/sip/service_test.go
+++ b/pkg/sip/service_test.go
@@ -49,6 +49,7 @@ func getResponseOrFail(t *testing.T, tx sip.ClientTransaction) *sip.Response {
 	return nil
 }
 func getResponseOrFailTimeout(t *testing.T, ctx context.Context, tx sip.ClientTransaction) *sip.Response {
+	t.Helper()
 	var ctxDone <-chan struct{} = nil
 	if ctx != nil {
 		ctxDone = ctx.Done()

--- a/pkg/sip/service_test.go
+++ b/pkg/sip/service_test.go
@@ -54,8 +54,7 @@ func getResponseOrFailTimeout(t *testing.T, ctx context.Context, tx sip.ClientTr
 		ctxDone = ctx.Done()
 	}
 	select {
-	case <-t.Context().Done():
-		t.Fatal("Test context cancelled")
+	// Avoid using t.Context, this helper is used in test cleanup code as well.
 	case <-ctxDone:
 		t.Fatal("Context cancelled")
 	case <-tx.Done():

--- a/pkg/sip/signaling_test.go
+++ b/pkg/sip/signaling_test.go
@@ -285,7 +285,7 @@ func (s *sipUATest) TransactionRequest(t *testing.T, req *sip.Request, isFromUAC
 	require.NoError(t, err)
 	defer tx.Terminate()
 
-	resp := getFinalResponseOrFail(t, tx, req)
+	resp := getFinalResponseOrFail(t, nil, tx)
 	if req.Method == sip.INVITE && resp.StatusCode < 300 {
 		// Need to send ACK for 2xx INVITE, sipgo already sends ACK for 3xx+
 		ack := sip.NewAckRequest(req, resp, nil)


### PR DESCRIPTION
- Prep for reconfigure: Introduced `changeSetSummary`, to allow skipping reconfig on changes that do not require it. Code paths still disabled.
- Re-introduce timeout control: One major deviation from main was found to be in the wait for room connection path: In new code, we would process invite, generate answer, and arm timeout immediately. However, we would not send the 200 back until room is entered. This would run the risk of timing out on media before remote could possibly even know where to send it. As a temp measure, we have renamed `SetTimeoutForDelayedAck` to `SetTimeout`, allowed to process offer without arming timeout, and added a call site to `SetTimeout` right after sending an INVITE-200 for inbound calls. 