### PR TITLE
Remove struct field inboundCall.audioOut and mirror existing transfer workflow.

### DIFF
--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -737,7 +737,6 @@ type inboundCall struct {
 	sigTs       SignalingTimestamps
 	jitterBuf   bool
 	projectID   string
-	audioOut    *msdk.WriteCloserSwitch[msdk.PCM16Sample] // inner writer owned by MediaPort
 }
 
 func (s *Server) newInboundCall(
@@ -767,7 +766,6 @@ func (s *Server) newInboundCall(
 		endCall:    make(chan EndCall, 1),
 		jitterBuf:  SelectValueBool(s.conf.EnableJitterBuffer, s.conf.EnableJitterBufferProb),
 		projectID:  "", // Will be set in handleInvite when available
-		audioOut:   msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate),
 	}
 	c.stats.Update()
 	c.setLog(log.WithValues("jitterBuf", c.jitterBuf))
@@ -955,6 +953,8 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		ackTimeout  <-chan time.Time
 	)
 
+	roomAudioOut := msdk.NewWriteCloserSwitch[msdk.PCM16Sample](RoomSampleRate)
+
 	acceptCall := func(answerData []byte) (bool, error) {
 		defer c.mon.StageDurTimer("call-accept")()
 		headers := disp.Headers
@@ -985,7 +985,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 			// Start this timer right after the Accept.
 			ackTimeout = time.After(inviteOkAckLateTimeout)
 		}
-		if old := c.audioOut.Swap(c.media.GetOutboundAudioWriter()); old != nil {
+		if old := roomAudioOut.Swap(c.media.GetOutboundAudioWriter()); old != nil {
 			c.log().Warnw("unexpected audio out writer", nil)
 			old.Close()
 		}
@@ -996,7 +996,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		return true, nil
 	}
 
-	if err := c.createMediaPort(mconf, conf, disp.FeatureFlags); err != nil {
+	if err := c.createMediaPort(mconf, conf, roomAudioOut, disp.FeatureFlags); err != nil {
 		return rejectMedia(err)
 	}
 
@@ -1160,7 +1160,7 @@ func (w *pinDTMFWriter) WriteSample(msg *livekit.SipDTMF) error {
 	return nil
 }
 
-func (c *inboundCall) createMediaPort(mconf *sipMediaConfig, conf *config.Config, featureFlags map[string]string) error {
+func (c *inboundCall) createMediaPort(mconf *sipMediaConfig, conf *config.Config, roomAudioOut *msdk.WriteCloserSwitch[msdk.PCM16Sample], featureFlags map[string]string) error {
 	c.mmu.Lock()
 	defer c.mmu.Unlock()
 	if c.media != nil {
@@ -1191,7 +1191,7 @@ func (c *inboundCall) createMediaPort(mconf *sipMediaConfig, conf *config.Config
 	c.mediaCodecs = mconf.Codecs
 
 	// Mixer is created with the room; attach it now so pin prompts can play.
-	if old := c.lkRoom.WriteOutboundAudioTo(c.audioOut); old != nil {
+	if old := c.lkRoom.WriteOutboundAudioTo(roomAudioOut); old != nil {
 		c.log().Warnw("room has unexpected outbound audio writer", nil)
 		old.Close()
 	}
@@ -1741,16 +1741,20 @@ func (c *inboundCall) transferCall(ctx context.Context, transferTo string, heade
 
 		// Mute the room audio to the SIP participant.
 		// Skip closing the existing writer, which is c.audioOut.
-		_ = c.lkRoom.WriteOutboundAudioTo(nil)
+		oldRoomAudioOut := c.lkRoom.WriteOutboundAudioTo(nil)
 
 		defer func() {
 			if retErr != nil && !c.done.Load() {
-				c.lkRoom.WriteOutboundAudioTo(c.audioOut)
+				c.lkRoom.WriteOutboundAudioTo(oldRoomAudioOut)
+			} else {
+				if err := oldRoomAudioOut.Close(); err != nil {
+					c.log().Warnw("failed to close old audio output", err)
+				}
 			}
 		}()
 
 		go func() {
-			err := tones.Play(rctx, c.audioOut, ringVolume, tones.ETSIRinging)
+			err := tones.Play(rctx, oldRoomAudioOut, ringVolume, tones.ETSIRinging)
 			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 				c.log().Infow("cannot play dial tone", "error", err)
 			}

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1736,11 +1736,8 @@ func (c *inboundCall) transferCall(ctx context.Context, transferTo string, heade
 
 	if dialtone && c.started.IsBroken() && !c.done.Load() {
 		const ringVolume = math.MaxInt16 / 2
-		rctx, rcancel := context.WithCancel(ctx)
-		defer rcancel()
 
 		// Mute the room audio to the SIP participant.
-		// Skip closing the existing writer, which is c.audioOut.
 		oldRoomAudioOut := c.lkRoom.WriteOutboundAudioTo(nil)
 
 		defer func() {
@@ -1752,6 +1749,9 @@ func (c *inboundCall) transferCall(ctx context.Context, transferTo string, heade
 				}
 			}
 		}()
+
+		rctx, rcancel := context.WithCancel(ctx)
+		defer rcancel()
 
 		go func() {
 			err := tones.Play(rctx, oldRoomAudioOut, ringVolume, tones.ETSIRinging)


### PR DESCRIPTION
Addressing [Denys' comment](https://github.com/livekit/sip/pull/802#discussion_r3829813941) on the refactor PR.