### PR TITLE
Add late SDP answer support for inbound calls.

### DIFF
--- a/pkg/sip/features.go
+++ b/pkg/sip/features.go
@@ -1,6 +1,16 @@
 package sip
 
+import "strconv"
+
 const (
 	signalLoggingFeatureFlag        = "sip.signal_logging"
 	outboundRouteHeadersFeatureFlag = "sip.outbound_route_headers"
+	lateOfferFeatureFlag            = "sip.late_offer"
 )
+
+// featureFlagEnabled reports whether a boolean feature flag is set to true.
+// Missing or unparsable values count as disabled.
+func featureFlagEnabled(flags map[string]string, flag string) bool {
+	enabled, _ := strconv.ParseBool(flags[flag])
+	return enabled
+}

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -409,6 +409,13 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	existing := s.byLocalTag[cc.ID()]
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
+		if existing.LateAnswerPending() {
+			// Our offer from the 200 OK has not been answered yet. Negotiating a new offer now would
+			// discard the pending one and break the late answer when the ACK arrives.
+			existing.log().Infow("rejecting reinvite, late answer pending", "cseq", cc.InviteCSeq())
+			cc.RejectAsKeepAlive(statusRequestPending, "Request Pending")
+			return nil
+		}
 		existing.log().Infow("reinvite", "content-length", req.ContentLength(), "cseq", cc.InviteCSeq())
 		if err := existing.updateRemoteFromSDP(sdpBodyFromRequest(req)); err != nil {
 			log.Errorw("failed to update inbound call SDP", err)
@@ -734,10 +741,13 @@ type inboundCall struct {
 	joinDur     func() time.Duration
 	done        atomic.Bool
 	started     core.Fuse
-	stats       Stats
-	sigTs       SignalingTimestamps
-	jitterBuf   bool
-	projectID   string
+	// lateAnswerPending is set while we have sent an SDP offer in the 200 OK and have not yet
+	// processed the answer from the ACK.
+	lateAnswerPending atomic.Bool
+	stats             Stats
+	sigTs             SignalingTimestamps
+	jitterBuf         bool
+	projectID         string
 }
 
 func (s *Server) newInboundCall(
@@ -961,6 +971,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	var sdpBody []byte
 	expectingLateAnswer := len(rawSDP) == 0
 	if expectingLateAnswer {
+		c.lateAnswerPending.Store(true)
 		sdpBody, err = c.media.GenerateOffer()
 		if err != nil {
 			return rejectMedia(err)
@@ -1309,6 +1320,8 @@ func (c *inboundCall) negotiateMedia(sdpData []byte) ([]byte, error) {
 func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
 	c.mmu.Lock()
 	defer c.mmu.Unlock()
+	defer c.lateAnswerPending.Store(false)
+
 	if c.media == nil {
 		return errors.New("media port not created")
 	}
@@ -1326,6 +1339,13 @@ func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
 	}
 
 	return c.updateCallStateAudioLocked()
+}
+
+// LateAnswerPending reports whether the call sent an SDP offer in its 200 OK and is still
+// waiting for the answer in the ACK. While this is true, the offer/answer exchange is open
+// and a re-INVITE cannot be negotiated (RFC 3264 §5, RFC 3261 §14.2).
+func (c *inboundCall) LateAnswerPending() bool {
+	return c.lateAnswerPending.Load()
 }
 
 func (c *inboundCall) waitMedia(ctx context.Context) (bool, error) {
@@ -2257,6 +2277,12 @@ retries:
 }
 
 func (c *sipInbound) AcceptAck(req *sip.Request, tx sip.ServerTransaction) {
+	cseq := req.CSeq()
+	if cseq == nil || cseq.SeqNo != c.inviteCSeq {
+		c.log.Debugw("ignoring ACK for another INVITE", "inviteCSeq", c.inviteCSeq, "ackCSeq", cseq)
+		return
+	}
+	// Only store the first ACK seen.
 	c.ack.CompareAndSwap(nil, req)
 	c.acked.Break()
 }

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1074,7 +1074,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	return c.waitForCallEnd(ctx, ackReceived, ackTimeout, mconf.MediaTimeout)
 }
 
-func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData []byte, expectingLateOffer bool) error {
+func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData []byte, waitForAck bool) error {
 	headers := disp.Headers
 	c.attrsToHdr = disp.AttributesToHeaders
 	if r := c.lkRoom.Room(); r != nil {
@@ -1082,7 +1082,7 @@ func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData
 	}
 	c.log().Infow("Accepting the call", "headers", headers)
 	taccept := c.mon.StageDurTimer("sip-accept")
-	err := c.cc.Accept(ctx, sdpData, headers, expectingLateOffer)
+	err := c.cc.Accept(ctx, sdpData, headers, waitForAck)
 	taccept()
 	c.sigTs.AcceptTime = time.Now()
 	if errors.Is(err, errNoACK) {
@@ -1307,13 +1307,10 @@ func (c *inboundCall) negotiateMedia(sdpData []byte) ([]byte, error) {
 	}
 	defer c.mon.StageDurTimer("start-media")()
 
-	var answerData []byte
-	var err error
-
 	c.mon.SDPSize(len(sdpData), true)
 	c.log().Debugw("SDP offer", "sdp", string(sdpData))
 
-	answerData, err = c.media.GenerateAnswer(sdpData)
+	answerData, err := c.media.GenerateAnswer(sdpData)
 	if err != nil {
 		return nil, err
 	}
@@ -1346,7 +1343,6 @@ func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
 	if err := c.media.ProcessAnswer(answerData); err != nil {
 		return err
 	}
-	// The 200 OK carried our offer; re-INVITE replies must echo the negotiated SDP instead.
 	localSDP, err := c.media.GetLocalSDP()
 	if err != nil {
 		return err

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -958,10 +958,10 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		return rejectMedia(err)
 	}
 
-	var sdpResponseBody []byte
+	var sdpBody []byte
 	expectingLateAnswer := len(rawSDP) == 0
 	if expectingLateAnswer {
-		sdpResponseBody, err = c.media.GenerateOffer()
+		sdpBody, err = c.media.GenerateOffer()
 		if err != nil {
 			return rejectMedia(err)
 		}
@@ -973,13 +973,13 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		if !expectingLateAnswer {
 			// Negotiate before Accept so pin prompts and DTMF have a live pipeline.
 			// Encryption is picked here, before the room is selected.
-			sdpResponseBody, err = c.negotiateMedia(rawSDP)
+			sdpBody, err = c.negotiateMedia(rawSDP)
 			if err != nil {
 				return rejectMedia(err)
 			}
 		}
 		c.connectPinDTMF()
-		if ok, ackTimeout, err = c.acceptCallAndWaitForMedia(ctx, disp, sdpResponseBody, mconf.MediaTimeout, expectingLateAnswer); !ok {
+		if ok, ackTimeout, err = c.acceptCallAndWaitForMedia(ctx, disp, sdpBody, mconf.MediaTimeout, expectingLateAnswer); !ok {
 			return err // could be success if the caller hung up
 		}
 		disp, ok, err = c.pinPrompt(ctx, trunkID)
@@ -1003,11 +1003,9 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	status := CallRinging
 	if pinPrompt {
 		status = CallActive
-	}
-
-	// We can't negotiate media until we've received an answer.
-	if !expectingLateAnswer && !pinPrompt {
-		sdpResponseBody, err = c.negotiateMedia(rawSDP)
+	} else if !expectingLateAnswer {
+		// We can't negotiate media until we've received an answer.
+		sdpBody, err = c.negotiateMedia(rawSDP)
 		if err != nil {
 			return rejectMedia(err)
 		}
@@ -1032,7 +1030,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		if ok, err := c.waitSubscribe(ctx, disp.RingingTimeout); !ok {
 			return err // already sent a response. Could be success if caller hung up
 		}
-		if ok, ackTimeout, err = c.acceptCallAndWaitForMedia(ctx, disp, sdpResponseBody, mconf.MediaTimeout, expectingLateAnswer); !ok {
+		if ok, ackTimeout, err = c.acceptCallAndWaitForMedia(ctx, disp, sdpBody, mconf.MediaTimeout, expectingLateAnswer); !ok {
 			return err // already sent a response. Could be success if caller hung up
 		}
 	}
@@ -1292,13 +1290,14 @@ func (c *inboundCall) negotiateMedia(sdpData []byte) ([]byte, error) {
 	var answerData []byte
 	var err error
 
-	c.mon.SDPSize(len(sdpData) /*isOffer=*/, true)
+	c.mon.SDPSize(len(sdpData), true)
 	c.log().Debugw("SDP offer", "sdp", string(sdpData))
 
-	if answerData, err = c.media.GenerateAnswer(sdpData); err != nil {
+	answerData, err = c.media.GenerateAnswer(sdpData)
+	if err != nil {
 		return nil, err
 	}
-	c.mon.SDPSize(len(answerData) /*isOffer=*/, false)
+	c.mon.SDPSize(len(answerData), false)
 	c.log().Debugw("SDP answer", "sdp", string(answerData))
 
 	if err = c.updateCallStateAudioLocked(); err != nil {
@@ -1320,7 +1319,7 @@ func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
 
 	// TODO(alexfish): Should we create a new stats histogram for late
 	// answers?
-	c.mon.SDPSize(len(answerData) /*isOffer=*/, false)
+	c.mon.SDPSize(len(answerData), false)
 	c.log().Debugw("Late SDP answer", "sdp", string(answerData))
 	if err := c.media.ProcessAnswer(answerData); err != nil {
 		return err

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -985,6 +985,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		if err != nil {
 			return rejectMedia(err)
 		}
+		c.mon.SDPSize(len(sdpBody), true)
 	}
 
 	ok := false

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -968,8 +968,17 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		return rejectMedia(err)
 	}
 
+	var expectingLateAnswer bool
+	if len(rawSDP) == 0 {
+		expectingLateAnswer = featureFlagEnabled(disp.FeatureFlags, lateOfferFeatureFlag)
+		if !expectingLateAnswer {
+			log.Infow("Offerless INVITE, but late offer is not enabled for this project")
+		} else {
+			log.Infow("Offerless INVITE")
+		}
+	}
+
 	var sdpBody []byte
-	expectingLateAnswer := len(rawSDP) == 0
 	if expectingLateAnswer {
 		c.lateAnswerPending.Store(true)
 		sdpBody, err = c.media.GenerateOffer()

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -952,52 +952,6 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		ackTimeout  <-chan time.Time
 	)
 
-	acceptCall := func(answerData []byte) (bool, error) {
-		defer c.mon.StageDurTimer("call-accept")()
-		headers := disp.Headers
-		c.attrsToHdr = disp.AttributesToHeaders
-		if r := c.lkRoom.Room(); r != nil {
-			headers = AttrsToHeaders(r.LocalParticipant.Attributes(), c.attrsToHdr, headers)
-		}
-		c.log().Infow("Accepting the call", "headers", headers)
-		taccept := c.mon.StageDurTimer("sip-accept")
-		err := c.cc.Accept(ctx, answerData, headers)
-		taccept()
-		c.sigTs.AcceptTime = time.Now()
-		if errors.Is(err, errNoACK) {
-			c.log().Errorw("Call accepted, but no ACK received", err)
-			c.closeWithNoACK(ctx)
-			return false, err
-		} else if err != nil {
-			c.log().Errorw("Cannot accept the call", err)
-			c.close(ctx, EndCall{
-				Status: callAcceptFailed,
-				Term:   stats.ServerError("accept-failed"),
-			})
-			return false, err
-		}
-		c.media.SetTimeout(c.s.conf.MediaTimeoutInitial, mconf.MediaTimeout) // Only enable media timeout once we send back SDP.
-		if !c.s.conf.Experimental.InboundWaitACK {
-			ackReceived = c.cc.InviteACK()
-			// Start this timer right after the Accept.
-			ackTimeout = time.After(inviteOkAckLateTimeout)
-		}
-		// Attach room outputs
-		if old := c.lkRoom.WriteOutboundAudioTo(c.media.GetOutboundAudioWriter()); old != nil {
-			c.log().Warnw("room has unexpected outbound audio writer", nil)
-			old.Close()
-		}
-		if old := c.lkRoom.WriteOutboundDTMFTo(c.media.GetOutboundDTMFWriter()); old != nil {
-			c.log().Warnw("room has unexpected outbound audio DTMF writer", nil)
-			old.Close()
-		}
-		if ok, err := c.waitMedia(ctx); !ok {
-			return false, err
-		}
-		c.setStatus(CallActive)
-		return true, nil
-	}
-
 	if err := c.createMediaPort(mconf, conf, disp.FeatureFlags); err != nil {
 		return rejectMedia(err)
 	}
@@ -1012,7 +966,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 			return rejectMedia(err)
 		}
 		c.connectPinDTMF()
-		if ok, err = acceptCall(answerData); !ok {
+		if ok, ackTimeout, err = c.acceptAndStartCall(ctx, disp, answerData, mconf.MediaTimeout); !ok {
 			return err // could be success if the caller hung up
 		}
 		disp, ok, err = c.pinPrompt(ctx, trunkID)
@@ -1060,7 +1014,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		if ok, err := c.waitSubscribe(ctx, disp.RingingTimeout); !ok {
 			return err // already sent a response. Could be success if caller hung up
 		}
-		if ok, err := acceptCall(answerData); !ok {
+		if ok, ackTimeout, err = c.acceptAndStartCall(ctx, disp, answerData, mconf.MediaTimeout); !ok {
 			return err // already sent a response. Could be success if caller hung up
 		}
 	}
@@ -1076,7 +1030,67 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	})
 
 	c.started.Break()
+
+	if !conf.Experimental.InboundWaitACK {
+		ackReceived = c.cc.InviteACK()
+	}
+
 	return c.waitForCallEnd(ctx, ackReceived, ackTimeout, mconf.MediaTimeout)
+}
+
+func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData []byte) error {
+	headers := disp.Headers
+	c.attrsToHdr = disp.AttributesToHeaders
+	if r := c.lkRoom.Room(); r != nil {
+		headers = AttrsToHeaders(r.LocalParticipant.Attributes(), c.attrsToHdr, headers)
+	}
+	c.log().Infow("Accepting the call", "headers", headers)
+	taccept := c.mon.StageDurTimer("sip-accept")
+	err := c.cc.Accept(ctx, sdpData, headers)
+	taccept()
+	c.sigTs.AcceptTime = time.Now()
+	if errors.Is(err, errNoACK) {
+		c.log().Errorw("Call accepted, but no ACK received", err)
+		c.closeWithNoACK(ctx)
+		return err
+	} else if err != nil {
+		c.log().Errorw("Cannot accept the call", err)
+		c.close(ctx, EndCall{
+			Status: callAcceptFailed,
+			Term:   stats.ServerError("accept-failed"),
+		})
+		return err
+	}
+	return nil
+}
+
+func (c *inboundCall) acceptAndStartCall(ctx context.Context, disp CallDispatch, answerData []byte, mediaTimeout time.Duration) (bool, <-chan time.Time, error) {
+	defer c.mon.StageDurTimer("call-accept")()
+	if err := c.acceptCall(ctx, disp, answerData); err != nil {
+		return false, nil, err
+	}
+
+	var ackTimeout <-chan time.Time
+
+	c.media.SetTimeout(c.s.conf.MediaTimeoutInitial, mediaTimeout) // Only enable media timeout once we send back SDP.
+	if !c.s.conf.Experimental.InboundWaitACK {
+		// Start this timer right after the Accept.
+		ackTimeout = time.After(inviteOkAckLateTimeout)
+	}
+	// Attach room outputs
+	if old := c.lkRoom.WriteOutboundAudioTo(c.media.GetOutboundAudioWriter()); old != nil {
+		c.log().Warnw("room has unexpected outbound audio writer", nil)
+		old.Close()
+	}
+	if old := c.lkRoom.WriteOutboundDTMFTo(c.media.GetOutboundDTMFWriter()); old != nil {
+		c.log().Warnw("room has unexpected outbound audio DTMF writer", nil)
+		old.Close()
+	}
+	if ok, err := c.waitMedia(ctx); !ok {
+		return false, nil, err
+	}
+	c.setStatus(CallActive)
+	return true, ackTimeout, nil
 }
 
 func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan struct{}, ackTimeout <-chan time.Time, mediaTimeout time.Duration) error {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -76,6 +76,8 @@ var errNoACK = errors.New("no ACK received for 200 OK")
 // RFC 3261 §21.4.27 / §14.2 — glare: INVITE received while an INVITE we sent is in progress.
 const statusRequestPending sip.StatusCode = 491
 
+const contentTypeSDP string = "application/sdp"
+
 // hashPassword creates a SHA256 hash of the password for logging purposes
 func hashPassword(password string) string {
 	if password == "" {
@@ -316,7 +318,7 @@ func (s *Server) handleInviteAuth(tid traceid.ID, log logger.Logger, req *sip.Re
 
 func sdpBodyFromRequest(req *sip.Request) []byte {
 	ct := req.ContentType()
-	if ct != nil && ct.Value() != "application/sdp" {
+	if ct != nil && ct.Value() != contentTypeSDP {
 		return nil
 	}
 	return req.Body()
@@ -912,7 +914,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		switch h.Value() {
 		default:
 			log.Infow("unsupported offer type")
-		case "application/sdp":
+		case contentTypeSDP:
 		}
 	} else {
 		log.Infow("no offer type specified")
@@ -956,17 +958,28 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		return rejectMedia(err)
 	}
 
-	ok := false
-	var answerData []byte
-	if pinPrompt {
-		// Negotiate before Accept so pin prompts and DTMF have a live pipeline.
-		// Encryption is picked here, before the room is selected.
-		answerData, err = c.negotiateMedia(rawSDP)
+	var sdpResponseBody []byte
+	expectingLateAnswer := len(rawSDP) == 0
+	if expectingLateAnswer {
+		sdpResponseBody, err = c.media.GenerateOffer()
 		if err != nil {
 			return rejectMedia(err)
 		}
+	}
+
+	ok := false
+	if pinPrompt {
+		// We can't negotiate media until we receive an answer.
+		if !expectingLateAnswer {
+			// Negotiate before Accept so pin prompts and DTMF have a live pipeline.
+			// Encryption is picked here, before the room is selected.
+			sdpResponseBody, err = c.negotiateMedia(rawSDP)
+			if err != nil {
+				return rejectMedia(err)
+			}
+		}
 		c.connectPinDTMF()
-		if ok, ackTimeout, err = c.acceptAndStartCall(ctx, disp, answerData, mconf.MediaTimeout); !ok {
+		if ok, ackTimeout, err = c.acceptCallAndWaitForMedia(ctx, disp, sdpResponseBody, mconf.MediaTimeout, expectingLateAnswer); !ok {
 			return err // could be success if the caller hung up
 		}
 		disp, ok, err = c.pinPrompt(ctx, trunkID)
@@ -991,10 +1004,15 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	if pinPrompt {
 		status = CallActive
 	}
-	answerData, err = c.negotiateMedia(rawSDP)
-	if err != nil {
-		return rejectMedia(err)
+
+	// We can't negotiate media until we've received an answer.
+	if !expectingLateAnswer && !pinPrompt {
+		sdpResponseBody, err = c.negotiateMedia(rawSDP)
+		if err != nil {
+			return rejectMedia(err)
+		}
 	}
+
 	if err := c.joinRoom(ctx, disp.Room, status); err != nil {
 		return fmt.Errorf("failed joining room: %w", err)
 	}
@@ -1014,7 +1032,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		if ok, err := c.waitSubscribe(ctx, disp.RingingTimeout); !ok {
 			return err // already sent a response. Could be success if caller hung up
 		}
-		if ok, ackTimeout, err = c.acceptAndStartCall(ctx, disp, answerData, mconf.MediaTimeout); !ok {
+		if ok, ackTimeout, err = c.acceptCallAndWaitForMedia(ctx, disp, sdpResponseBody, mconf.MediaTimeout, expectingLateAnswer); !ok {
 			return err // already sent a response. Could be success if caller hung up
 		}
 	}
@@ -1031,14 +1049,14 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 
 	c.started.Break()
 
-	if !conf.Experimental.InboundWaitACK {
+	if !expectingLateAnswer && !conf.Experimental.InboundWaitACK {
 		ackReceived = c.cc.InviteACK()
 	}
 
 	return c.waitForCallEnd(ctx, ackReceived, ackTimeout, mconf.MediaTimeout)
 }
 
-func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData []byte) error {
+func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData []byte, expectingLateOffer bool) error {
 	headers := disp.Headers
 	c.attrsToHdr = disp.AttributesToHeaders
 	if r := c.lkRoom.Room(); r != nil {
@@ -1046,7 +1064,7 @@ func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData
 	}
 	c.log().Infow("Accepting the call", "headers", headers)
 	taccept := c.mon.StageDurTimer("sip-accept")
-	err := c.cc.Accept(ctx, sdpData, headers)
+	err := c.cc.Accept(ctx, sdpData, headers, expectingLateOffer)
 	taccept()
 	c.sigTs.AcceptTime = time.Now()
 	if errors.Is(err, errNoACK) {
@@ -1064,19 +1082,8 @@ func (c *inboundCall) acceptCall(ctx context.Context, disp CallDispatch, sdpData
 	return nil
 }
 
-func (c *inboundCall) acceptAndStartCall(ctx context.Context, disp CallDispatch, answerData []byte, mediaTimeout time.Duration) (bool, <-chan time.Time, error) {
-	defer c.mon.StageDurTimer("call-accept")()
-	if err := c.acceptCall(ctx, disp, answerData); err != nil {
-		return false, nil, err
-	}
-
-	var ackTimeout <-chan time.Time
-
+func (c *inboundCall) waitForMedia(ctx context.Context, mediaTimeout time.Duration) (bool, error) {
 	c.media.SetTimeout(c.s.conf.MediaTimeoutInitial, mediaTimeout) // Only enable media timeout once we send back SDP.
-	if !c.s.conf.Experimental.InboundWaitACK {
-		// Start this timer right after the Accept.
-		ackTimeout = time.After(inviteOkAckLateTimeout)
-	}
 	// Attach room outputs
 	if old := c.lkRoom.WriteOutboundAudioTo(c.media.GetOutboundAudioWriter()); old != nil {
 		c.log().Warnw("room has unexpected outbound audio writer", nil)
@@ -1087,10 +1094,45 @@ func (c *inboundCall) acceptAndStartCall(ctx context.Context, disp CallDispatch,
 		old.Close()
 	}
 	if ok, err := c.waitMedia(ctx); !ok {
-		return false, nil, err
+		return false, err
 	}
 	c.setStatus(CallActive)
-	return true, ackTimeout, nil
+	return true, nil
+}
+
+func (c *inboundCall) acceptCallAndWaitForMedia(ctx context.Context, disp CallDispatch, sdpResponseBody []byte, mediaTimeout time.Duration, expectingLateAnswer bool) (bool, <-chan time.Time, error) {
+	defer c.mon.StageDurTimer("call-accept")()
+	waitForAck := expectingLateAnswer || c.s.conf.Experimental.InboundWaitACK
+	if err := c.acceptCall(ctx, disp, sdpResponseBody, waitForAck); err != nil {
+		return false, nil, err
+	}
+	var ackTimeout <-chan time.Time
+	if !waitForAck {
+		// Start this timer right after the Accept.
+		ackTimeout = time.After(inviteOkAckLateTimeout)
+	}
+
+	if expectingLateAnswer {
+		ack := c.cc.Ack()
+		if ack == nil {
+			c.log().Errorw("ack not found", nil)
+			return false, nil, fmt.Errorf("ack not found")
+		}
+
+		// The offer should now be here.
+		sdp := ack.Body()
+		if h := ack.ContentType(); h != nil {
+			if h.Value() != contentTypeSDP {
+				c.log().Infow("unsupported content type", "contentType", h.Value())
+			}
+		}
+		if err := c.negotiateMediaForLateAnswer(sdp); err != nil {
+			return false, nil, err
+		}
+	}
+
+	ok, err := c.waitForMedia(ctx, mediaTimeout)
+	return ok, ackTimeout, err
 }
 
 func (c *inboundCall) waitForCallEnd(ctx context.Context, ackReceived <-chan struct{}, ackTimeout <-chan time.Time, mediaTimeout time.Duration) error {
@@ -1224,7 +1266,19 @@ func (c *inboundCall) connectPinDTMF() {
 	}
 }
 
-func (c *inboundCall) negotiateMedia(offerData []byte) ([]byte, error) {
+// REQUIRES: c.mmu is held.
+func (c *inboundCall) updateCallStateAudioLocked() error {
+	audio := c.media.NegotiatedAudio()
+	if audio == nil {
+		return fmt.Errorf("media does not have negotiated audio")
+	}
+	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
+		info.AudioCodec = audio.Codec.Info().SDPName
+	})
+	return nil
+}
+
+func (c *inboundCall) negotiateMedia(sdpData []byte) ([]byte, error) {
 	c.mmu.Lock()
 	defer c.mmu.Unlock()
 	if c.media == nil {
@@ -1233,27 +1287,46 @@ func (c *inboundCall) negotiateMedia(offerData []byte) ([]byte, error) {
 	if c.media.NegotiatedAudio() != nil {
 		return c.media.GetLocalSDP()
 	}
-
 	defer c.mon.StageDurTimer("start-media")()
-	c.mon.SDPSize(len(offerData), true)
-	c.log().Debugw("SDP offer", "sdp", string(offerData))
 
-	answerData, err := c.media.GenerateAnswer(offerData)
-	if err != nil {
+	var answerData []byte
+	var err error
+
+	c.mon.SDPSize(len(sdpData) /*isOffer=*/, true)
+	c.log().Debugw("SDP offer", "sdp", string(sdpData))
+
+	if answerData, err = c.media.GenerateAnswer(sdpData); err != nil {
 		return nil, err
 	}
-
-	c.mon.SDPSize(len(answerData), false)
+	c.mon.SDPSize(len(answerData) /*isOffer=*/, false)
 	c.log().Debugw("SDP answer", "sdp", string(answerData))
 
-	audio := c.media.NegotiatedAudio()
-	if audio == nil {
-		return nil, fmt.Errorf("media does not have negotiated audio")
+	if err = c.updateCallStateAudioLocked(); err != nil {
+		return nil, err
 	}
-	c.state.DeferUpdate(func(info *livekit.SIPCallInfo) {
-		info.AudioCodec = audio.Codec.Info().SDPName
-	})
 	return answerData, nil
+}
+
+func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
+	c.mmu.Lock()
+	defer c.mmu.Unlock()
+	if c.media == nil {
+		return errors.New("media port not created")
+	}
+	if c.media.NegotiatedAudio() != nil {
+		return nil
+	}
+	defer c.mon.StageDurTimer("process-late-answer")()
+
+	// TODO(alexfish): Should we create a new stats histogram for late
+	// answers?
+	c.mon.SDPSize(len(answerData) /*isOffer=*/, false)
+	c.log().Debugw("Late SDP answer", "sdp", string(answerData))
+	if err := c.media.ProcessAnswer(answerData); err != nil {
+		return err
+	}
+
+	return c.updateCallStateAudioLocked()
 }
 
 func (c *inboundCall) waitMedia(ctx context.Context) (bool, error) {
@@ -1899,6 +1972,7 @@ type sipInbound struct {
 	referCseq       uint32
 	ringing         chan struct{}
 	acked           core.Fuse
+	ack             atomic.Pointer[sip.Request] // non-nil once acked is broken
 	call            *inboundCall
 }
 
@@ -2115,7 +2189,7 @@ func (c *sipInbound) OwnSDP() []byte {
 	return c.lastSDP
 }
 
-func (c *sipInbound) Accept(ctx context.Context, sdpData []byte, headers map[string]string) error {
+func (c *sipInbound) Accept(ctx context.Context, sdpData []byte, headers map[string]string, waitForAck bool) error {
 	ctx, span := Tracer.Start(ctx, "sip.inbound.Accept")
 	defer span.End()
 	c.mu.Lock()
@@ -2138,7 +2212,7 @@ func (c *sipInbound) Accept(ctx context.Context, sdpData []byte, headers map[str
 	c.stopRinging()
 	retryAfter := inviteOkRetryInterval
 	maxRetries := inviteOKRetryAttempts
-	if !c.s.conf.Experimental.InboundWaitACK {
+	if !waitForAck {
 		// Still retry, but limit it to ~750ms.
 		maxRetries = inviteOKRetryAttemptsNoACK
 	}
@@ -2153,7 +2227,7 @@ retries:
 		if err := c.inviteTx.Respond(r); err != nil {
 			return err
 		}
-		if c.legTr != TransportUDP && !c.s.conf.Experimental.InboundWaitACK {
+		if !waitForAck && c.legTr != TransportUDP {
 			// Reliable transport and we are not waiting for ACK - return immediately.
 			break retries
 		}
@@ -2170,7 +2244,7 @@ retries:
 		if try > maxRetries {
 			// Only set error if an option is enabled.
 			// Otherwise, ignore missing ACK for now.
-			if c.s.conf.Experimental.InboundWaitACK {
+			if waitForAck {
 				acceptErr = errNoACK
 			}
 			break retries
@@ -2184,7 +2258,13 @@ retries:
 }
 
 func (c *sipInbound) AcceptAck(req *sip.Request, tx sip.ServerTransaction) {
+	c.ack.CompareAndSwap(nil, req)
 	c.acked.Break()
+}
+
+// Ack returns the first ACK seen for this call.
+func (c *sipInbound) Ack() *sip.Request {
+	return c.ack.Load()
 }
 
 func (c *sipInbound) AcceptBye(req *sip.Request, tx sip.ServerTransaction) {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -1346,6 +1346,12 @@ func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
 	if err := c.media.ProcessAnswer(answerData); err != nil {
 		return err
 	}
+	// The 200 OK carried our offer; re-INVITE replies must echo the negotiated SDP instead.
+	localSDP, err := c.media.GetLocalSDP()
+	if err != nil {
+		return err
+	}
+	c.cc.SetOwnSDP(localSDP)
 
 	return c.updateCallStateAudioLocked()
 }
@@ -2215,6 +2221,12 @@ func (c *sipInbound) OwnSDP() []byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	return c.lastSDP
+}
+
+func (c *sipInbound) SetOwnSDP(sdpData []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastSDP = sdpData
 }
 
 func (c *sipInbound) Accept(ctx context.Context, sdpData []byte, headers map[string]string, waitForAck bool) error {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -409,9 +409,7 @@ func (s *Server) processInvite(req *sip.Request, tx sip.ServerTransaction) (retE
 	existing := s.byLocalTag[cc.ID()]
 	s.cmu.RUnlock()
 	if existing != nil && existing.cc.InviteCSeq() < cc.InviteCSeq() {
-		if existing.LateAnswerPending() {
-			// Our offer from the 200 OK has not been answered yet. Negotiating a new offer now would
-			// discard the pending one and break the late answer when the ACK arrives.
+		if existing.lateAnswerPending.Load() {
 			existing.log().Infow("rejecting reinvite, late answer pending", "cseq", cc.InviteCSeq())
 			cc.RejectAsKeepAlive(statusRequestPending, "Request Pending")
 			return nil
@@ -718,32 +716,30 @@ func (s *Server) onNotify(log *slog.Logger, req *sip.Request, tx sip.ServerTrans
 }
 
 type inboundCall struct {
-	s           *Server
-	tid         traceid.ID
-	logPtr      atomic.Pointer[logger.Logger]
-	cc          *sipInbound
-	mon         *stats.CallMonitor
-	state       *CallState
-	callStart   time.Time
-	extraAttrs  map[string]string
-	attrsToHdr  map[string]string
-	ctx         context.Context
-	cancel      func()
-	closeReason atomic.Pointer[ReasonHeader]
-	call        *rpc.SIPCall
-	mmu         sync.Mutex
-	media       MediaPort
-	mediaCodecs *msdk.CodecSet
-	dtmf        chan dtmf.Event // buffered
-	endCall     chan EndCall    // buffered
-	lkRoom      RoomInterface   // LiveKit room; only active after correct pin is entered
-	callDur     func() time.Duration
-	joinDur     func() time.Duration
-	done        atomic.Bool
-	started     core.Fuse
-	// lateAnswerPending is set while we have sent an SDP offer in the 200 OK and have not yet
-	// processed the answer from the ACK.
-	lateAnswerPending atomic.Bool
+	s                 *Server
+	tid               traceid.ID
+	logPtr            atomic.Pointer[logger.Logger]
+	cc                *sipInbound
+	mon               *stats.CallMonitor
+	state             *CallState
+	callStart         time.Time
+	extraAttrs        map[string]string
+	attrsToHdr        map[string]string
+	ctx               context.Context
+	cancel            func()
+	closeReason       atomic.Pointer[ReasonHeader]
+	call              *rpc.SIPCall
+	mmu               sync.Mutex
+	media             MediaPort
+	mediaCodecs       *msdk.CodecSet
+	dtmf              chan dtmf.Event // buffered
+	endCall           chan EndCall    // buffered
+	lkRoom            RoomInterface   // LiveKit room; only active after correct pin is entered
+	callDur           func() time.Duration
+	joinDur           func() time.Duration
+	done              atomic.Bool
+	started           core.Fuse
+	lateAnswerPending atomic.Bool // later offer generated, answer pending
 	stats             Stats
 	sigTs             SignalingTimestamps
 	jitterBuf         bool
@@ -914,7 +910,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		pinPrompt = true
 	}
 
-	rawSDP := req.Body()
+	sdpOffer := req.Body()
 	log := c.log()
 	if h := req.ContentLength(); h != nil {
 		log = log.WithValues("contentLength", int(*h))
@@ -932,7 +928,7 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 
 	rejectMedia := func(err error) error {
 		sipReason := sip.StatusInternalServerError
-		log := log.WithValues("sdp", string(rawSDP))
+		log := log.WithValues("sdp", string(sdpOffer))
 		status, term := callDropped, stats.ServerError("media-failed")
 		if errors.Is(err, sdp.ErrNoCommonMedia) {
 			status, term = callMediaFailed, stats.ClientError("no-common-codec")
@@ -968,37 +964,32 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 		return rejectMedia(err)
 	}
 
+	var sdpBody []byte // To be sent with 200 OK
 	var expectingLateAnswer bool
-	if len(rawSDP) == 0 {
-		expectingLateAnswer = featureFlagEnabled(disp.FeatureFlags, lateOfferFeatureFlag)
-		if !expectingLateAnswer {
-			log.Infow("Offerless INVITE, but late offer is not enabled for this project")
-		} else {
-			log.Infow("Offerless INVITE")
+	if len(sdpOffer) == 0 {
+		if !featureFlagEnabled(disp.FeatureFlags, lateOfferFeatureFlag) {
+			err := SDPError{Err: fmt.Errorf("received INVITE without offer, late offer disabled")}
+			return rejectMedia(err)
 		}
-	}
-
-	var sdpBody []byte
-	if expectingLateAnswer {
+		log.Infow("later offer enabled")
+		expectingLateAnswer = true
 		c.lateAnswerPending.Store(true)
 		sdpBody, err = c.media.GenerateOffer()
 		if err != nil {
 			return rejectMedia(err)
 		}
-		c.mon.SDPSize(len(sdpBody), true)
+		c.mon.SDPSize(len(sdpBody), true, false)
+	} else {
+		c.mon.SDPSize(len(sdpOffer), true, true)
+		sdpBody, err = c.negotiateMedia(sdpOffer)
+		if err != nil {
+			return rejectMedia(err)
+		}
+		c.mon.SDPSize(len(sdpBody), false, false)
 	}
 
 	ok := false
 	if pinPrompt {
-		// We can't negotiate media until we receive an answer.
-		if !expectingLateAnswer {
-			// Negotiate before Accept so pin prompts and DTMF have a live pipeline.
-			// Encryption is picked here, before the room is selected.
-			sdpBody, err = c.negotiateMedia(rawSDP)
-			if err != nil {
-				return rejectMedia(err)
-			}
-		}
 		c.connectPinDTMF()
 		if ok, ackTimeout, err = c.acceptCallAndWaitForMedia(ctx, disp, sdpBody, mconf.MediaTimeout, expectingLateAnswer); !ok {
 			return err // could be success if the caller hung up
@@ -1024,12 +1015,6 @@ func (c *inboundCall) handleInvite(ctx context.Context, tid traceid.ID, req *sip
 	status := CallRinging
 	if pinPrompt {
 		status = CallActive
-	} else if !expectingLateAnswer {
-		// We can't negotiate media until we've received an answer.
-		sdpBody, err = c.negotiateMedia(rawSDP)
-		if err != nil {
-			return rejectMedia(err)
-		}
 	}
 
 	if err := c.joinRoom(ctx, disp.Room, status); err != nil {
@@ -1145,6 +1130,7 @@ func (c *inboundCall) acceptCallAndWaitForMedia(ctx context.Context, disp CallDi
 				c.log().Infow("unsupported content type", "contentType", h.Value())
 			}
 		}
+		c.mon.SDPSize(len(sdp), false, true)
 		if err := c.negotiateMediaForLateAnswer(sdp); err != nil {
 			return false, nil, err
 		}
@@ -1297,7 +1283,7 @@ func (c *inboundCall) updateCallStateAudioLocked() error {
 	return nil
 }
 
-func (c *inboundCall) negotiateMedia(sdpData []byte) ([]byte, error) {
+func (c *inboundCall) negotiateMedia(sdpOffer []byte) ([]byte, error) {
 	c.mmu.Lock()
 	defer c.mmu.Unlock()
 	if c.media == nil {
@@ -1308,14 +1294,12 @@ func (c *inboundCall) negotiateMedia(sdpData []byte) ([]byte, error) {
 	}
 	defer c.mon.StageDurTimer("start-media")()
 
-	c.mon.SDPSize(len(sdpData), true)
-	c.log().Debugw("SDP offer", "sdp", string(sdpData))
+	c.log().Debugw("SDP offer", "sdp", string(sdpOffer))
 
-	answerData, err := c.media.GenerateAnswer(sdpData)
+	answerData, err := c.media.GenerateAnswer(sdpOffer)
 	if err != nil {
 		return nil, err
 	}
-	c.mon.SDPSize(len(answerData), false)
 	c.log().Debugw("SDP answer", "sdp", string(answerData))
 
 	if err = c.updateCallStateAudioLocked(); err != nil {
@@ -1337,9 +1321,6 @@ func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
 	}
 	defer c.mon.StageDurTimer("process-late-answer")()
 
-	// TODO(alexfish): Should we create a new stats histogram for late
-	// answers?
-	c.mon.SDPSize(len(answerData), false)
 	c.log().Debugw("Late SDP answer", "sdp", string(answerData))
 	if err := c.media.ProcessAnswer(answerData); err != nil {
 		return err
@@ -1351,13 +1332,6 @@ func (c *inboundCall) negotiateMediaForLateAnswer(answerData []byte) error {
 	c.cc.SetOwnSDP(localSDP)
 
 	return c.updateCallStateAudioLocked()
-}
-
-// LateAnswerPending reports whether the call sent an SDP offer in its 200 OK and is still
-// waiting for the answer in the ACK. While this is true, the offer/answer exchange is open
-// and a re-INVITE cannot be negotiated (RFC 3264 §5, RFC 3261 §14.2).
-func (c *inboundCall) LateAnswerPending() bool {
-	return c.lateAnswerPending.Load()
 }
 
 func (c *inboundCall) waitMedia(ctx context.Context) (bool, error) {

--- a/pkg/sip/inbound.go
+++ b/pkg/sip/inbound.go
@@ -2188,6 +2188,8 @@ func (c *sipInbound) RejectAsKeepAlive(status sip.StatusCode, reason string) {
 	c.respond(status, reason)
 }
 
+// TODO(alexfish): Remove this function in favor once re-invites are
+// consistently responded to with the MediaPort's local SDP.
 func (c *sipInbound) OwnSDP() []byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/pkg/sip/inbound_test.go
+++ b/pkg/sip/inbound_test.go
@@ -15,12 +15,17 @@
 package sip
 
 import (
+	"context"
+	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/livekit/media-sdk/sdp"
 	"github.com/livekit/protocol/livekit"
 	"github.com/livekit/sip/pkg/stats"
+	"github.com/livekit/sipgo/sip"
 )
 
 func TestProviderLabel(t *testing.T) {
@@ -69,4 +74,268 @@ func TestProviderLabel(t *testing.T) {
 			require.Equal(t, c.exp, providerLabel(c.info))
 		})
 	}
+}
+
+// lateOfferCall is an inbound call started with an offerless INVITE (RFC 3261 §13.2.1, "late offer").
+type lateOfferCall struct {
+	st     *serviceTest
+	call   *sipUADialogTest
+	invite *sip.Request
+	tx     sip.ClientTransaction
+	byes   <-chan *sipUARequest // BYE requests sent by the server for this dialog
+
+	// Set by expectOffer.
+	ok    *sip.Response // first 200 OK received
+	offer *sdp.Offer    // SDP offer carried by the 200 OK
+	ic    *inboundCall
+}
+
+// inviteWithoutOffer sends an INVITE with no body.
+func (st *serviceTest) inviteWithoutOffer(t *testing.T) *lateOfferCall {
+	t.Helper()
+
+	call := newTestCall(st.TestUA, false)
+	byes := call.RegisterRequestChannel(string(sip.BYE))
+	t.Cleanup(func() { call.UnregisterRequestChannel(string(sip.BYE)) })
+
+	req := call.NewRequest(sip.INVITE) // no body, no Content-Type
+	tx, err := st.TestUA.Client.TransactionRequest(req)
+	require.NoError(t, err)
+	t.Cleanup(tx.Terminate)
+
+	return &lateOfferCall{
+		st:     st,
+		call:   call,
+		invite: req,
+		tx:     tx,
+		byes:   byes,
+	}
+}
+
+// requireOffer asserts that resp is a 200 OK carrying an SDP offer, and returns the parsed offer.
+func requireOffer(t *testing.T, resp *sip.Response) *sdp.Offer {
+	t.Helper()
+	require.Equal(t, sip.StatusCode(200), resp.StatusCode, "offerless INVITE should get 200 OK")
+	ct := resp.ContentType()
+	require.NotNil(t, ct, "200 OK for an offerless INVITE must declare a Content-Type")
+	require.Equal(t, contentTypeSDP, ct.Value())
+	require.NotEmpty(t, resp.Body(), "200 OK for an offerless INVITE must carry an SDP offer")
+	offer, err := sdp.ParseOfferWith(defaultCodecs, resp.Body())
+	require.NoError(t, err, "200 OK body should be a parsable SDP offer")
+	return offer
+}
+
+// expectOffer waits for the final response to the INVITE and asserts it is a 200 OK with an SDP offer.
+func (c *lateOfferCall) expectOffer(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	resp := getFinalResponseOrFail(t, ctx, c.tx)
+	c.ok = resp
+	c.offer = requireOffer(t, resp)
+
+	remoteTag, ok := resp.To().Params.Get("tag")
+	require.True(t, ok, "remote tag should be present")
+	c.call.SetRemoteTag(LocalTag(remoteTag))
+	c.call.SetRemoteSDP(resp.Body())
+	c.call.SetRouteSet(resp, true)
+
+	c.st.Server.cmu.Lock()
+	c.ic, ok = c.st.Server.byLocalTag[c.call.remoteTag]
+	c.st.Server.cmu.Unlock()
+	require.True(t, ok, "call should be registered")
+}
+
+// requireRetransmit asserts that resp is a retransmission of the 200 OK recorded by expectOffer.
+func (c *lateOfferCall) requireRetransmit(t *testing.T, resp *sip.Response) {
+	t.Helper()
+	require.Equal(t, sip.StatusCode(200), resp.StatusCode, "retransmission should be a 200 OK")
+	require.Equal(t, c.ok.To().Params.GetOr("tag", ""), resp.To().Params.GetOr("tag", ""), "retransmission should belong to the same dialog")
+	require.Equal(t, c.ok.Body(), resp.Body(), "retransmission should carry the same offer")
+}
+
+// media returns the call's media port.
+func (c *lateOfferCall) media() MediaPort {
+	c.ic.mmu.Lock()
+	defer c.ic.mmu.Unlock()
+	return c.ic.media
+}
+
+// answer builds an SDP answer for the offer received in the 200 OK.
+func (c *lateOfferCall) answer(t *testing.T, addr netip.AddrPort) []byte {
+	t.Helper()
+	ans, _, err := c.offer.Answer(addr.Addr(), int(addr.Port()), sdp.EncryptionNone)
+	require.NoError(t, err)
+	data, err := ans.SDP.Marshal()
+	require.NoError(t, err)
+	return data
+}
+
+func (c *lateOfferCall) ack(t *testing.T, body []byte) {
+	t.Helper()
+	ack := sip.NewAckRequest(c.invite, c.ok, body)
+	if body != nil {
+		ack.AppendHeader(sip.NewHeader("Content-Type", contentTypeSDP))
+	}
+	require.NoError(t, c.st.TestUA.Client.WriteRequest(ack))
+}
+
+// nextResponse waits for another response on the INVITE transaction, i.e. a retransmitted 200 OK.
+func (c *lateOfferCall) nextResponse(t *testing.T, ctx context.Context) *sip.Response {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for a retransmitted response: %v", ctx.Err())
+	case <-c.tx.Done():
+		t.Fatal("INVITE transaction terminated while waiting for a retransmitted response")
+	case resp := <-c.tx.Responses():
+		return resp
+	}
+	return nil
+}
+
+// expectBye waits for the server to send a BYE for this dialog and answers it with 200 OK.
+func (c *lateOfferCall) expectBye(t *testing.T, ctx context.Context) {
+	t.Helper()
+	select {
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for BYE from server: %v", ctx.Err())
+	case msg := <-c.byes:
+		c.answerBye(t, msg)
+	}
+}
+
+// answerBye asserts that msg is a BYE for this dialog and answers it with 200 OK.
+func (c *lateOfferCall) answerBye(t *testing.T, msg *sipUARequest) {
+	t.Helper()
+	require.NotNil(t, msg)
+	require.Equal(t, sip.BYE, msg.req.Method)
+	require.Equal(t, string(c.call.localTag), msg.req.To().Params.GetOr("tag", ""))
+	require.NoError(t, msg.tx.Respond(sip.NewResponseFromRequest(msg.req, 200, "OK", nil)))
+}
+
+// expectActive asserts that the server has negotiated media.
+func (c *lateOfferCall) expectActive(t *testing.T, remote netip.AddrPort) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return c.media().NegotiatedAudio() != nil
+	}, 5*time.Second, 10*time.Millisecond, "media should be negotiated")
+	require.Equal(t, remote, getMediaPortRemoteAddr(t, c.media()), "RTP destination should come from the answer in the ACK")
+	require.True(t, c.ic.cc.GotACK(), "server should have recorded the ACK")
+	require.Eventually(t, c.ic.started.IsBroken, 5*time.Second, 10*time.Millisecond, "call should become active")
+	require.False(t, c.ic.done.Load(), "call should still be up")
+}
+
+// expectClosedWithoutMedia asserts the server tore the call down without ever
+// having negotiated media.
+func (c *lateOfferCall) expectClosedWithoutMedia(t *testing.T) {
+	t.Helper()
+	require.Eventually(t, c.ic.done.Load, 5*time.Second, 10*time.Millisecond, "call should be closed")
+	require.Nil(t, c.media().NegotiatedAudio(), "media must not be negotiated without a valid answer")
+}
+
+// hangup ends an established call from the caller side.
+func (c *lateOfferCall) hangup(t *testing.T) {
+	t.Helper()
+	resp := c.call.TransactionRequest(t, c.call.NewRequest(sip.BYE))
+	require.Equal(t, sip.StatusCode(200), resp.StatusCode, "BYE should get 200 OK")
+}
+
+func TestInboundLateOffer(t *testing.T) {
+	st := NewServiceTest(t, nil)
+	callerRTP := netip.MustParseAddrPort("127.0.0.1:2827")
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		c := st.inviteWithoutOffer(t)
+		c.expectOffer(t, ctx)
+
+		// The offer must point at the media port allocated for this call.
+		require.Equal(t, getMediaPort(t, c.media()).Port(), int(c.offer.Addr.Port()), "offer should advertise the call's RTP port")
+		// Nothing can be negotiated until the answer arrives.
+		require.Nil(t, c.media().NegotiatedAudio(), "media must not be negotiated before the ACK")
+
+		c.ack(t, c.answer(t, callerRTP))
+		c.expectActive(t, callerRTP)
+		t.Cleanup(func() { c.hangup(t) })
+
+		// Once ACKed, the 200 OK must not be retransmitted.
+		expectNoResponse(t, c.tx)
+	})
+
+	t.Run("delayed_ack", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		c := st.inviteWithoutOffer(t)
+		c.expectOffer(t, ctx)
+
+		// Withhold the ACK: the UAS must retransmit the 200 OK, with the same offer.
+		c.requireRetransmit(t, c.nextResponse(t, ctx))
+		require.Nil(t, c.media().NegotiatedAudio(), "media must not be negotiated before the ACK")
+
+		c.ack(t, c.answer(t, callerRTP))
+		c.expectActive(t, callerRTP)
+		t.Cleanup(func() { c.hangup(t) })
+
+		expectNoResponse(t, c.tx)
+	})
+
+	t.Run("ack_never_arrives", func(t *testing.T) {
+		t.Parallel()
+		// UDP retries back off from 250ms to 3s; giving up takes ~10s.
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		defer cancel()
+
+		c := st.inviteWithoutOffer(t)
+		c.expectOffer(t, ctx)
+
+		// Count 200 OK retransmissions until the server gives up and sends BYE.
+		retransmits := 0
+	loop:
+		for {
+			select {
+			case <-ctx.Done():
+				t.Fatalf("timed out waiting for the server to give up on the ACK: %v", ctx.Err())
+			case resp := <-c.tx.Responses():
+				c.requireRetransmit(t, resp)
+				retransmits++
+			case msg := <-c.byes:
+				c.answerBye(t, msg)
+				break loop
+			}
+		}
+		require.GreaterOrEqual(t, retransmits, 2, "200 OK should be retransmitted while waiting for the ACK")
+		require.False(t, c.ic.cc.GotACK(), "server received unexpected ACK")
+		c.expectClosedWithoutMedia(t)
+	})
+
+	t.Run("ack_without_answer", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		c := st.inviteWithoutOffer(t)
+		c.expectOffer(t, ctx)
+		c.ack(t, nil)
+
+		c.expectBye(t, ctx)
+		c.expectClosedWithoutMedia(t)
+	})
+
+	t.Run("ack_with_invalid_answer", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		c := st.inviteWithoutOffer(t)
+		c.expectOffer(t, ctx)
+		c.ack(t, []byte("invalid SDP answer"))
+
+		c.expectBye(t, ctx)
+		c.expectClosedWithoutMedia(t)
+	})
 }

--- a/pkg/sip/inbound_test.go
+++ b/pkg/sip/inbound_test.go
@@ -256,8 +256,30 @@ func (c *lateOfferCall) hangup(t *testing.T) {
 	require.Equal(t, sip.StatusCode(200), resp.StatusCode, "BYE should get 200 OK")
 }
 
+func TestInboundLateOfferDisabled(t *testing.T) {
+	// No feature flags: late offer is off for the project.
+	st := NewServiceTest(t, nil)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+
+	c := st.inviteWithoutOffer(t)
+	resp := getFinalResponseOrFail(t, ctx, c.tx)
+	// Same rejection as before late offer support: negotiating an empty offer fails.
+	require.Equal(t, sip.StatusInternalServerError, resp.StatusCode, "offerless INVITE should be rejected when late offer is disabled")
+	require.Empty(t, resp.Body(), "rejection must not carry an offer")
+
+	// The response is sent before the call is deregistered.
+	require.Eventually(t, func() bool {
+		st.Server.cmu.RLock()
+		defer st.Server.cmu.RUnlock()
+		return len(st.Server.byLocalTag) == 0
+	}, 5*time.Second, 10*time.Millisecond, "rejected call should be deregistered")
+}
+
 func TestInboundLateOffer(t *testing.T) {
 	st := NewServiceTest(t, nil)
+	// Enable late offer at the project level.
+	st.Server.SetHandler(&TestHandler{FeatureFlags: map[string]string{lateOfferFeatureFlag: "true"}})
 	callerRTP := netip.MustParseAddrPort("127.0.0.1:2827")
 
 	t.Run("success", func(t *testing.T) {

--- a/pkg/sip/inbound_test.go
+++ b/pkg/sip/inbound_test.go
@@ -395,8 +395,13 @@ func TestInboundLateOffer(t *testing.T) {
 		c.expectActive(t, callerRTP)
 		t.Cleanup(func() { c.hangup(t) })
 
-		// With the exchange complete, re-INVITEs are accepted again.
+		// With the exchange complete, re-INVITEs are accepted again, and the reply must be the
+		// negotiated SDP rather than the multi-codec offer we sent in the original 200 OK.
 		resp = c.reinvite(t, ctx)
 		require.Equal(t, sip.StatusCode(200), resp.StatusCode, "re-INVITE after the late answer should get 200 OK")
+		localSDP, err := c.media().GetLocalSDP()
+		require.NoError(t, err)
+		require.Equal(t, localSDP, resp.Body(), "re-INVITE reply should carry the negotiated local SDP")
+		require.NotEqual(t, c.ok.Body(), resp.Body(), "re-INVITE reply must not echo the original offer")
 	})
 }

--- a/pkg/sip/inbound_test.go
+++ b/pkg/sip/inbound_test.go
@@ -233,6 +233,22 @@ func (c *lateOfferCall) expectClosedWithoutMedia(t *testing.T) {
 	require.Nil(t, c.media().NegotiatedAudio(), "media must not be negotiated without a valid answer")
 }
 
+// reinvite sends an in-dialog INVITE with a fresh offer from the caller and returns the final response.
+// sipgo ACKs non-2xx responses itself; a 2xx is ACKed here.
+func (c *lateOfferCall) reinvite(t *testing.T, ctx context.Context) *sip.Response {
+	t.Helper()
+	req, _, err := c.call.Invite(nil)
+	require.NoError(t, err)
+	tx, err := c.st.TestUA.Client.TransactionRequest(req)
+	require.NoError(t, err)
+	t.Cleanup(tx.Terminate)
+	resp := getFinalResponseOrFail(t, ctx, tx)
+	if resp.StatusCode < 300 {
+		require.NoError(t, c.st.TestUA.Client.WriteRequest(sip.NewAckRequest(req, resp, nil)))
+	}
+	return resp
+}
+
 // hangup ends an established call from the caller side.
 func (c *lateOfferCall) hangup(t *testing.T) {
 	t.Helper()
@@ -337,5 +353,28 @@ func TestInboundLateOffer(t *testing.T) {
 
 		c.expectBye(t, ctx)
 		c.expectClosedWithoutMedia(t)
+	})
+
+	t.Run("reinvite_before_ack", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+		defer cancel()
+
+		c := st.inviteWithoutOffer(t)
+		c.expectOffer(t, ctx)
+
+		// Our offer is still unanswered: a re-INVITE cannot be negotiated yet.
+		resp := c.reinvite(t, ctx)
+		require.Equal(t, statusRequestPending, resp.StatusCode, "re-INVITE before the late answer should get 491")
+		require.Nil(t, c.media().NegotiatedAudio(), "rejected re-INVITE must not negotiate media")
+
+		// The pending exchange still completes normally.
+		c.ack(t, c.answer(t, callerRTP))
+		c.expectActive(t, callerRTP)
+		t.Cleanup(func() { c.hangup(t) })
+
+		// With the exchange complete, re-INVITEs are accepted again.
+		resp = c.reinvite(t, ctx)
+		require.Equal(t, sip.StatusCode(200), resp.StatusCode, "re-INVITE after the late answer should get 200 OK")
 	})
 }

--- a/pkg/sip/inbound_test.go
+++ b/pkg/sip/inbound_test.go
@@ -265,7 +265,7 @@ func TestInboundLateOfferDisabled(t *testing.T) {
 	c := st.inviteWithoutOffer(t)
 	resp := getFinalResponseOrFail(t, ctx, c.tx)
 	// Same rejection as before late offer support: negotiating an empty offer fails.
-	require.Equal(t, sip.StatusInternalServerError, resp.StatusCode, "offerless INVITE should be rejected when late offer is disabled")
+	require.Equal(t, sip.StatusBadRequest, resp.StatusCode, "offerless INVITE should be rejected when late offer is disabled")
 	require.Empty(t, resp.Body(), "rejection must not carry an offer")
 
 	// The response is sent before the call is deregistered.

--- a/pkg/sip/outbound.go
+++ b/pkg/sip/outbound.go
@@ -713,7 +713,7 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 	if err != nil {
 		return err
 	}
-	c.mon.SDPSize(len(sdpOfferData), true)
+	c.mon.SDPSize(len(sdpOfferData), true, false)
 	c.log.Debugw("SDP offer", "sdp", string(sdpOfferData))
 	joinDur := c.mon.JoinDur()
 
@@ -762,7 +762,7 @@ func (c *outboundCall) sipSignal(ctx context.Context, tid traceid.ID) error {
 		return err
 	}
 	c.sigTs.AcceptTime = time.Now()
-	c.mon.SDPSize(len(sdpResp), false)
+	c.mon.SDPSize(len(sdpResp), false, true)
 	c.log.Debugw("SDP answer", "sdp", string(sdpResp))
 
 	c.log = LoggerWithHeaders(c.log, c.cc)

--- a/pkg/sip/service_test.go
+++ b/pkg/sip/service_test.go
@@ -95,6 +95,8 @@ type TestHandler struct {
 	DispatchCallFunc       func(ctx context.Context, info *CallInfo) CallDispatch
 	OnInboundInfoFunc      func(log logger.Logger, call *rpc.SIPCall, headers Headers)
 	OnSessionEndFunc       func(ctx context.Context, callIdentifier *CallIdentifier, state *CallState, reason string)
+	// FeatureFlags are returned by the default DispatchCall.
+	FeatureFlags map[string]string
 }
 
 func (h TestHandler) GetAuthCredentials(ctx context.Context, call *rpc.SIPCall) (AuthInfo, error) {
@@ -118,6 +120,7 @@ func (h TestHandler) DispatchCall(ctx context.Context, info *CallInfo) CallDispa
 				Name:     identity,
 			},
 		},
+		FeatureFlags: h.FeatureFlags,
 	}
 }
 

--- a/pkg/stats/monitor.go
+++ b/pkg/stats/monitor.go
@@ -243,7 +243,7 @@ func (m *Monitor) Start(conf *config.Config) error {
 		Help:        "SDP size in bytes",
 		ConstLabels: prometheus.Labels{"node_id": conf.NodeID},
 		Buckets:     sizeBuckets,
-	}, []string{"type"}))
+	}, []string{"type", "source"}))
 
 	m.sdpParsed = mustRegister(m, prometheus.NewCounterVec(prometheus.CounterOpts{
 		Namespace:   "livekit",
@@ -540,12 +540,16 @@ func (c *CallMonitor) PeerSDP(names []string, reinvite bool) {
 	}
 }
 
-func (c *CallMonitor) SDPSize(sz int, isOffer bool) {
+func (c *CallMonitor) SDPSize(sz int, isOffer bool, isFromRemote bool) {
 	typ := "answer"
 	if isOffer {
 		typ = "offer"
 	}
-	c.m.sdpSize.WithLabelValues(typ).Observe(float64(sz))
+	source := "local"
+	if isFromRemote {
+		source = "remote"
+	}
+	c.m.sdpSize.WithLabelValues(typ, source).Observe(float64(sz))
 }
 
 func (m *Monitor) TransferStarted(dir CallDir) {


### PR DESCRIPTION
- Whenever we don't receive an offer with the initial invite, we respond with a 200 and an SDP offer, and we expect an ACK to eventually arrive with an answer
  - In the event that we are waiting for a late answer, do not proceed with the call until we receive an ACK (previously, this logic was solely gated on some experimental flag being set)
  - Note: this is is gated by a feature-flag currently
- Small refactor of `acceptCall` function variable (defined in `handleInvite`)
  - Move logic out of function variable into three top-level functions: `acceptCallAndWaitForMedia`, `acceptCall`, and `waitForMedia`
- Reinvite handling for late offers
    - Reply with the negotiated SDP (rather than the offer we sent in response to the offerless INVITE)
- Tests
