### PR TITLE
Give each incoming SSRC its own jitter buffer so a transferred stream is not muted

### DIFF
--- a/pkg/sip/media_pipeline.go
+++ b/pkg/sip/media_pipeline.go
@@ -71,19 +71,21 @@ type mediaPortPipeline struct {
 	conf *MediaPortPipelineConfig // Expected to be owned by caller, not managed
 
 	// Owned by pipeline
-	ctx           context.Context
-	cancel        context.CancelFunc
-	sess          rtp.Session
-	rtpLoopWG     sync.WaitGroup
-	muxToRoom     atomic.Pointer[rtp.HandlerCloser]
-	dtmfMixer     *mixer.Mixer
-	audioToRoom   rtp.HandlerCloser
-	dtmfToRoom    rtp.HandlerCloser
-	dtmfHandler   msdk.WriteCloser[string] // Reference, not closed
-	audioToPort   msdk.PCM16Writer         // post-mixer chain towards port
-	mixerToPort   msdk.PCM16Writer         // Reference, not closed
-	dtmfToPort    msdk.WriteCloser[string]
-	lastDTMFEvent atomic.Uint64 // composite (timestamp, event code) of last DTMF packet seen
+	ctx                 context.Context
+	cancel              context.CancelFunc
+	sess                rtp.Session
+	rtpLoopWG           sync.WaitGroup
+	muxToRoom           atomic.Pointer[rtp.HandlerCloser] // shared inbound chain; jitter-free
+	inputChain          rtp.HandlerCloser                 // streamStats -> mux, wrapped per SSRC when jitter is on
+	inboundLatencyEntry atomic.Int64                      // shared entry timestamp for the inbound latency probe
+	dtmfMixer           *mixer.Mixer
+	audioToRoom         rtp.HandlerCloser
+	dtmfToRoom          rtp.HandlerCloser
+	dtmfHandler         msdk.WriteCloser[string] // Reference, not closed
+	audioToPort         msdk.PCM16Writer         // post-mixer chain towards port
+	mixerToPort         msdk.PCM16Writer         // Reference, not closed
+	dtmfToPort          msdk.WriteCloser[string]
+	lastDTMFEvent       atomic.Uint64 // composite (timestamp, event code) of last DTMF packet seen
 }
 
 // Returns insulated (nopCloser) connectors, preventing anchor close from closing pipeline.
@@ -154,9 +156,8 @@ func (p *mediaPortPipeline) init(
 // Construct the Audio and optionally DTMF pipeline from SIP RTP to LK PCM, in reverse order.
 func (p *mediaPortPipeline) setupInput(mc *sdp.MediaConfig, audioToRoom msdk.PCM16Writer, dtmfToRoom msdk.WriteCloser[string]) error {
 	var err error
-	var inboundLatencyEntry atomic.Int64
 	sink := msdk.NopCloser(audioToRoom) // Prevent pipeline close from closing room
-	sink = newLatencyPCMExit(sink, &inboundLatencyEntry, &p.conf.stats.LatencyInE2E)
+	sink = newLatencyPCMExit(sink, &p.inboundLatencyEntry, &p.conf.stats.LatencyInE2E)
 	codecInfo := mc.Audio.Codec.Info()
 	sink = msdk.ResampleWriter(sink, codecInfo.SampleRate)
 	sink = newMediaWriterCount(sink, &p.conf.stats.AudioInFrames, &p.conf.stats.AudioInSamples)
@@ -197,17 +198,54 @@ func (p *mediaPortPipeline) setupInput(mc *sdp.MediaConfig, audioToRoom msdk.PCM
 		mux.Register(mc.Audio.DTMFType, dtmfType)
 	}
 
-	var hnd rtp.HandlerCloser = newRTPStreamStats(mux, &p.conf.stats.MuxStats)
-	if p.conf.opts.EnableJitterBuffer {
-		hnd = rtp.HandleJitter(hnd, jitter.WithPacketLossHandler(func(packetsLost, packetsDropped uint64) {
-			p.conf.stats.JitterBufferPacketsLost.Store(packetsLost)
-			p.conf.stats.JitterBufferPacketsDropped.Store(packetsDropped)
-		}))
-	}
-	hnd = newLatencyRTPEntry(hnd, &inboundLatencyEntry)
+	// The jitter buffer is deliberately NOT part of this shared chain. A jitter
+	// buffer tracks one sequence-number space, and each SSRC has its own, so
+	// rtpReadLoop wraps the chain with a fresh buffer per stream (newStreamHandler).
+	p.inputChain = newRTPStreamStats(mux, &p.conf.stats.MuxStats)
 
+	hnd := newLatencyRTPEntry(p.inputChain, &p.inboundLatencyEntry)
 	p.muxToRoom.Store(&hnd)
 	return nil
+}
+
+// nopCloseRTPHandler lets a per-stream wrapper (e.g. a jitter buffer) be closed
+// without closing the shared chain underneath it.
+type nopCloseRTPHandler struct {
+	rtp.HandlerCloser
+}
+
+func (nopCloseRTPHandler) Close() {}
+
+// newStreamHandler returns the inbound handler for one RTP read stream (one SSRC).
+//
+// Without a jitter buffer every stream shares muxToRoom. With a jitter buffer
+// each stream gets its own, because jitter.Buffer keys everything off the last
+// popped sequence number and a new SSRC (a B2BUA transfer, a PBX relaying a new
+// leg) starts an unrelated sequence space. Sharing one buffer made any new
+// stream whose first sequence number fell within 32768 *behind* the old one be
+// dropped as "expired" until it caught up, i.e. silence for minutes.
+//
+// Returns nil if the pipeline has already been closed.
+func (p *mediaPortPipeline) newStreamHandler() rtp.HandlerCloser {
+	ptr := p.muxToRoom.Load()
+	if ptr == nil || *ptr == nil {
+		return nil
+	}
+	if !p.conf.opts.EnableJitterBuffer {
+		return nopCloseRTPHandler{*ptr} // shared; owned and closed by the pipeline
+	}
+	// Per-buffer counters are cumulative for that buffer only; fold deltas into
+	// the port-wide stats so the "call statistics" line keeps counting across SSRCs.
+	var lastLost, lastDropped uint64
+	hnd := rtp.HandleJitter(
+		nopCloseRTPHandler{p.inputChain},
+		jitter.WithPacketLossHandler(func(packetsLost, packetsDropped uint64) {
+			p.conf.stats.JitterBufferPacketsLost.Add(packetsLost - lastLost)
+			p.conf.stats.JitterBufferPacketsDropped.Add(packetsDropped - lastDropped)
+			lastLost, lastDropped = packetsLost, packetsDropped
+		}),
+	)
+	return newLatencyRTPEntry(hnd, &p.inboundLatencyEntry)
 }
 
 // Processes an incoming telephony-event packet, turns into SipDTMF, and forwards it.
@@ -319,6 +357,17 @@ func (p *mediaPortPipeline) rtpReadLoop(log logger.Logger, r rtp.ReadStream) {
 		h        rtp.Header
 		errorCnt int
 	)
+	hnd := p.newStreamHandler()
+	if hnd == nil {
+		// Pipeline already closed; drain until the stream ends so the session can shut down.
+		for {
+			if _, err := r.ReadRTP(&h, buf); err != nil {
+				return
+			}
+			p.conf.stats.IgnoredPackets.Add(1)
+		}
+	}
+	defer hnd.Close() // closes only the per-stream jitter buffer (if any)
 	for {
 		h = rtp.Header{}
 		n, err := r.ReadRTP(&h, buf)
@@ -341,16 +390,6 @@ func (p *mediaPortPipeline) rtpReadLoop(log logger.Logger, r rtp.ReadStream) {
 			continue // ignore partial messages
 		}
 
-		ptr := p.muxToRoom.Load()
-		if ptr == nil {
-			p.conf.stats.IgnoredPackets.Add(1)
-			continue
-		}
-		hnd := *ptr
-		if hnd == nil {
-			p.conf.stats.IgnoredPackets.Add(1)
-			continue
-		}
 		err = hnd.HandleRTP(&h, buf[:n])
 		if err != nil {
 			log := log.WithValues(

--- a/pkg/sip/media_pipeline.go
+++ b/pkg/sip/media_pipeline.go
@@ -227,6 +227,8 @@ func (nopCloseRTPHandler) Close() {}
 //
 // Returns nil if the pipeline has already been closed.
 func (p *mediaPortPipeline) newStreamHandler() rtp.HandlerCloser {
+	// muxToRoom doubles as the "pipeline still open" flag: it is cleared in Close() after
+	// every read loop has exited. inputChain is stable once setupInput returns.
 	ptr := p.muxToRoom.Load()
 	if ptr == nil || *ptr == nil {
 		return nil
@@ -359,7 +361,9 @@ func (p *mediaPortPipeline) rtpReadLoop(log logger.Logger, r rtp.ReadStream) {
 	)
 	hnd := p.newStreamHandler()
 	if hnd == nil {
-		// Pipeline already closed; drain until the stream ends so the session can shut down.
+		// Defensive: cannot happen today, because Close() clears muxToRoom only after
+		// rtpLoopWG.Wait() and rtpLoop itself is in that group. If it ever does, drain
+		// until the stream ends so the session can shut down.
 		for {
 			if _, err := r.ReadRTP(&h, buf); err != nil {
 				return

--- a/pkg/sip/media_pipeline_test.go
+++ b/pkg/sip/media_pipeline_test.go
@@ -695,6 +695,41 @@ func TestMediaPipelineJitterStatsAccumulateAcrossSSRC(t *testing.T) {
 	assert.Equal(t, uint64(0), h.pipeline.conf.stats.JitterBufferPacketsDropped.Load())
 }
 
+// Covers the defensive "pipeline already closed" path: once muxToRoom is
+// cleared, newStreamHandler returns nil and a read loop that starts in that
+// state drains its stream, counting packets as ignored, without touching the
+// chain. Close() cannot reach this state today (it waits for the read loops
+// first), so the test forces it directly.
+func TestMediaPipelineReadLoopAfterHandlerCleared(t *testing.T) {
+	codec := audioCodecByName(t, g711.ULawSDPNameAndRate)
+	h := newPipelineHarness(t, RoomSampleRate)
+	h.jitter = true
+	h.configure(codec, testAudioPT(codec), testDTMFPT, false)
+
+	old := h.pipeline.muxToRoom.Swap(nil)
+	require.NotNil(t, old)
+	require.Nil(t, h.pipeline.newStreamHandler(), "no handler once the pipeline is marked closed")
+
+	before := h.roomAudio.len()
+	h.injectAudio(0xDEAD, 1, 160, h.codecFrame())
+	require.Eventually(t, func() bool {
+		return h.pipeline.conf.stats.IgnoredPackets.Load() >= 1
+	}, time.Second, 5*time.Millisecond, "packet should be drained and counted as ignored")
+	assert.Equal(t, uint64(1), h.ssrcCount.Load())
+	assert.Equal(t, before, h.roomAudio.len(), "nothing must reach the room without a handler")
+
+	// Put the chain back so Close() releases it, then close with the draining loop still blocked in ReadRTP.
+	h.pipeline.muxToRoom.Store(old)
+	done := make(chan error, 1)
+	go func() { done <- h.pipeline.Close() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("pipeline.Close hung with a draining read loop")
+	}
+}
+
 func TestMediaPipelineReuseUDPConn(t *testing.T) {
 	const rate = 48000
 	d := pipelineTestDTMF[1] // event-only

--- a/pkg/sip/media_pipeline_test.go
+++ b/pkg/sip/media_pipeline_test.go
@@ -596,6 +596,60 @@ func TestMediaPipelineConcurrentSSRCPump(t *testing.T) {
 	}
 }
 
+// Reproduces a PBX transfer: the far end keeps the same 5-tuple but starts
+// relaying a different source, so LiveKit sees a new SSRC whose sequence
+// numbers are far *behind* the previous stream. Before the fix, every packet
+// of the new stream was rejected by the shared jitter buffer as "expired".
+func TestMediaPipelineJitterNewSSRCBackwardSeq(t *testing.T) {
+	const (
+		oldSSRC = uint32(0xA0000001)
+		newSSRC = uint32(0xB0000002)
+		oldSeq  = uint16(21280) // old stream ends near 21294 like the captured call
+		newSeq  = uint16(12676) // new stream starts here: 8618 behind, inside the 32768 half-space
+		perSSRC = 15
+	)
+	codec := audioCodecByName(t, g711.ULawSDPNameAndRate)
+	h := newPipelineHarness(t, RoomSampleRate)
+	h.jitter = true
+	h.configure(codec, testAudioPT(codec), testDTMFPT, false)
+
+	clock := codec.Info().RTPClockRate
+	if clock == 0 {
+		clock = codec.Info().SampleRate
+	}
+	samplesPerFrame := uint32(clock / int(time.Second/msrtp.DefFrameDur))
+	sample := h.codecFrame()
+
+	// Phase 1: original stream decodes.
+	// Pace the injections: media-sdk's per-SSRC read stream buffers 10 packets
+	// and drops on overflow, so a tight burst would lose packets at the socket.
+	for i := uint16(0); i < perSSRC; i++ {
+		h.injectAudio(oldSSRC, oldSeq+i, samplesPerFrame*uint32(i+1), sample)
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.Eventually(t, func() bool { return h.roomAudio.len() > 0 },
+		2*time.Second, 5*time.Millisecond, "original stream should decode")
+	afterOld := h.roomAudio.len()
+
+	// Phase 2: transfer. New SSRC, sequence space restarts far behind prevSN.
+	for i := uint16(0); i < perSSRC; i++ {
+		h.injectAudio(newSSRC, newSeq+i, samplesPerFrame*uint32(i+1), sample)
+		time.Sleep(2 * time.Millisecond)
+	}
+	require.Eventually(t, func() bool { return h.packetCount.Load() >= 2*perSSRC },
+		2*time.Second, 5*time.Millisecond, "all RTP should be read from the socket")
+	require.Eventually(t, func() bool { return h.roomAudio.len() > afterOld },
+		2*time.Second, 5*time.Millisecond,
+		"audio from the new SSRC must reach the room (dropped=%d, audioPackets=%d)",
+		h.pipeline.conf.stats.JitterBufferPacketsDropped.Load(),
+		h.pipeline.conf.stats.AudioPackets.Load())
+	require.Eventually(t, func() bool { return h.pipeline.conf.stats.AudioPackets.Load() >= 2*perSSRC },
+		2*time.Second, 5*time.Millisecond, "every packet of both streams should pass the jitter buffer")
+	assert.Equal(t, uint64(0), h.pipeline.conf.stats.JitterBufferPacketsDropped.Load(),
+		"a new SSRC must not be treated as expired packets of the old one")
+	assert.Equal(t, uint64(2), h.ssrcCount.Load())
+}
+
 func TestMediaPipelineReuseUDPConn(t *testing.T) {
 	const rate = 48000
 	d := pipelineTestDTMF[1] // event-only

--- a/pkg/sip/media_pipeline_test.go
+++ b/pkg/sip/media_pipeline_test.go
@@ -519,80 +519,90 @@ func TestMediaPipelinePermutations(t *testing.T) {
 }
 
 func TestMediaPipelineTeardownMultiSSRC(t *testing.T) {
-	codec := audioCodecByName(t, g711.ULawSDPNameAndRate)
-	h := newPipelineHarness(t, RoomSampleRate)
-	h.configure(codec, testAudioPT(codec), testDTMFPT, false)
-	sample := h.codecFrame()
+	for _, jitter := range []bool{false, true} {
+		t.Run(fmt.Sprintf("jitter=%v", jitter), func(t *testing.T) {
+			codec := audioCodecByName(t, g711.ULawSDPNameAndRate)
+			h := newPipelineHarness(t, RoomSampleRate)
+			h.jitter = jitter
+			h.configure(codec, testAudioPT(codec), testDTMFPT, false)
+			sample := h.codecFrame()
 
-	h.injectAudio(0x11111111, 1, 160, sample)
-	h.injectAudio(0x22222222, 1, 160, sample)
+			h.injectAudio(0x11111111, 1, 160, sample)
+			h.injectAudio(0x22222222, 1, 160, sample)
 
-	require.Eventually(t, func() bool {
-		return h.ssrcCount.Load() >= 2 && h.packetCount.Load() >= 2
-	}, time.Second, 5*time.Millisecond, "expected AcceptStream and HandleRTP for two SSRCs")
-	assert.Equal(t, uint64(2), h.ssrcCount.Load())
-	assert.Equal(t, uint64(2), h.packetCount.Load())
+			require.Eventually(t, func() bool {
+				return h.ssrcCount.Load() >= 2 && h.packetCount.Load() >= 2
+			}, time.Second, 5*time.Millisecond, "expected AcceptStream and HandleRTP for two SSRCs")
+			assert.Equal(t, uint64(2), h.ssrcCount.Load())
+			assert.Equal(t, uint64(2), h.packetCount.Load())
 
-	done := make(chan error, 1)
-	go func() {
-		done <- h.pipeline.Close()
-	}()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("pipeline.Close hung with multiple SSRCs")
+			done := make(chan error, 1)
+			go func() {
+				done <- h.pipeline.Close()
+			}()
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(2 * time.Second):
+				t.Fatal("pipeline.Close hung with multiple SSRCs")
+			}
+		})
 	}
 }
 
 func TestMediaPipelineConcurrentSSRCPump(t *testing.T) {
-	const (
-		ssrcCount = 3
-		packets   = 30 // Currently the built-in limit of media-sdk's ssrc mux
-	)
-	codec := audioCodecByName(t, g711.ULawSDPNameAndRate)
-	h := newPipelineHarness(t, RoomSampleRate)
-	h.configure(codec, testAudioPT(codec), testDTMFPT, false)
+	for _, jitter := range []bool{false, true} {
+		t.Run(fmt.Sprintf("jitter=%v", jitter), func(t *testing.T) {
+			const (
+				ssrcCount = 3
+				packets   = 30 // Currently the built-in limit of media-sdk's ssrc mux
+			)
+			codec := audioCodecByName(t, g711.ULawSDPNameAndRate)
+			h := newPipelineHarness(t, RoomSampleRate)
+			h.jitter = jitter
+			h.configure(codec, testAudioPT(codec), testDTMFPT, false)
 
-	silence := make(msdk.PCM16Sample, codec.Info().SampleRate/int(time.Second/msrtp.DefFrameDur))
-	var encoded msrtp.Buffer
-	clock := codec.Info().RTPClockRate
-	if clock == 0 {
-		clock = codec.Info().SampleRate
-	}
-	enc := msrtp.EncodePCM(msrtp.NewSeqWriter(&encoded).NewStream(h.audioPT, clock), h.codec)
-	require.NoError(t, enc.WriteSample(silence))
-	require.NoError(t, enc.Close())
-	require.NotEmpty(t, encoded, "codec produced no RTP")
-	payload := slices.Clone(encoded[0].Payload)
+			silence := make(msdk.PCM16Sample, codec.Info().SampleRate/int(time.Second/msrtp.DefFrameDur))
+			var encoded msrtp.Buffer
+			clock := codec.Info().RTPClockRate
+			if clock == 0 {
+				clock = codec.Info().SampleRate
+			}
+			enc := msrtp.EncodePCM(msrtp.NewSeqWriter(&encoded).NewStream(h.audioPT, clock), h.codec)
+			require.NoError(t, enc.WriteSample(silence))
+			require.NoError(t, enc.Close())
+			require.NotEmpty(t, encoded, "codec produced no RTP")
+			payload := slices.Clone(encoded[0].Payload)
 
-	pkt := &rtp.Packet{
-		Header: rtp.Header{
-			Version:     2,
-			PayloadType: h.audioPT,
-		},
-		Payload: payload,
-	}
-	for i := range packets {
-		pkt.SequenceNumber = uint16(i)
-		pkt.SSRC = uint32(i % ssrcCount)
-		h.injectRTP(pkt)
-	}
+			pkt := &rtp.Packet{
+				Header: rtp.Header{
+					Version:     2,
+					PayloadType: h.audioPT,
+				},
+				Payload: payload,
+			}
+			for i := range packets {
+				pkt.SequenceNumber = uint16(i)
+				pkt.SSRC = uint32(i % ssrcCount)
+				h.injectRTP(pkt)
+			}
 
-	require.Eventually(t, func() bool { return h.ssrcCount.Load() == ssrcCount }, time.Second, time.Millisecond, "expected %d SSRCs", ssrcCount)
-	assert.Eventually(t, func() bool { return h.packetCount.Load() == packets }, time.Second, time.Millisecond, "expected %d packets", packets)
-	assert.Equal(t, uint64(ssrcCount), h.ssrcCount.Load())
-	assert.Equal(t, uint64(packets), h.packetCount.Load())
+			require.Eventually(t, func() bool { return h.ssrcCount.Load() == ssrcCount }, time.Second, time.Millisecond, "expected %d SSRCs", ssrcCount)
+			assert.Eventually(t, func() bool { return h.packetCount.Load() == packets }, time.Second, time.Millisecond, "expected %d packets", packets)
+			assert.Equal(t, uint64(ssrcCount), h.ssrcCount.Load())
+			assert.Equal(t, uint64(packets), h.packetCount.Load())
 
-	done := make(chan error, 1)
-	go func() {
-		done <- h.pipeline.Close()
-	}()
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(2 * time.Second):
-		t.Fatal("pipeline.Close hung under concurrent SSRC pumps")
+			done := make(chan error, 1)
+			go func() {
+				done <- h.pipeline.Close()
+			}()
+			select {
+			case err := <-done:
+				require.NoError(t, err)
+			case <-time.After(2 * time.Second):
+				t.Fatal("pipeline.Close hung under concurrent SSRC pumps")
+			}
+		})
 	}
 }
 
@@ -680,7 +690,8 @@ func TestMediaPipelineJitterStatsAccumulateAcrossSSRC(t *testing.T) {
 		return h.pipeline.conf.stats.JitterBufferPacketsLost.Load() >= 4
 	}, 2*time.Second, 5*time.Millisecond, "lost=%d should be the sum over both SSRCs, not the last buffer's count",
 		h.pipeline.conf.stats.JitterBufferPacketsLost.Load())
-	assert.Equal(t, uint64(4), h.pipeline.conf.stats.JitterBufferPacketsLost.Load())
+	// >= not ==: a scheduler stall can add a socket-level drop that is counted as loss.
+	assert.GreaterOrEqual(t, h.pipeline.conf.stats.JitterBufferPacketsLost.Load(), uint64(4))
 	assert.Equal(t, uint64(0), h.pipeline.conf.stats.JitterBufferPacketsDropped.Load())
 }
 

--- a/pkg/sip/media_pipeline_test.go
+++ b/pkg/sip/media_pipeline_test.go
@@ -650,6 +650,40 @@ func TestMediaPipelineJitterNewSSRCBackwardSeq(t *testing.T) {
 	assert.Equal(t, uint64(2), h.ssrcCount.Load())
 }
 
+func TestMediaPipelineJitterStatsAccumulateAcrossSSRC(t *testing.T) {
+	codec := audioCodecByName(t, g711.ULawSDPNameAndRate)
+	h := newPipelineHarness(t, RoomSampleRate)
+	h.jitter = true
+	h.configure(codec, testAudioPT(codec), testDTMFPT, false)
+
+	clock := codec.Info().RTPClockRate
+	if clock == 0 {
+		clock = codec.Info().SampleRate
+	}
+	spf := uint32(clock / int(time.Second/msrtp.DefFrameDur))
+	sample := h.codecFrame()
+
+	// Each stream: seq 1,2,3 then skip 4,5 then 6,7,8 => 2 lost per stream.
+	inject := func(ssrc uint32) {
+		for _, seq := range []uint16{1, 2, 3, 6, 7, 8} {
+			h.injectAudio(ssrc, seq, spf*uint32(seq), sample)
+			time.Sleep(2 * time.Millisecond) // per-SSRC read stream drops on a 10-packet burst
+		}
+	}
+	inject(0x1111)
+	inject(0x2222)
+
+	require.Eventually(t, func() bool { return h.packetCount.Load() >= 12 },
+		2*time.Second, 5*time.Millisecond)
+	// Loss is only declared once the gap expires (60ms jitter latency), so wait.
+	require.Eventually(t, func() bool {
+		return h.pipeline.conf.stats.JitterBufferPacketsLost.Load() >= 4
+	}, 2*time.Second, 5*time.Millisecond, "lost=%d should be the sum over both SSRCs, not the last buffer's count",
+		h.pipeline.conf.stats.JitterBufferPacketsLost.Load())
+	assert.Equal(t, uint64(4), h.pipeline.conf.stats.JitterBufferPacketsLost.Load())
+	assert.Equal(t, uint64(0), h.pipeline.conf.stats.JitterBufferPacketsDropped.Load())
+}
+
 func TestMediaPipelineReuseUDPConn(t *testing.T) {
 	const rate = 48000
 	d := pipelineTestDTMF[1] // event-only

--- a/pkg/sip/media_pipeline_test.go
+++ b/pkg/sip/media_pipeline_test.go
@@ -181,6 +181,7 @@ type pipelineHarness struct {
 	codec       msdk.AudioCodec
 	audioPT     byte
 	dtmfPT      byte
+	jitter      bool // when true, configure() enables the jitter buffer
 }
 
 func newPipelineHarness(t *testing.T, sampleRate int) *pipelineHarness {
@@ -240,7 +241,7 @@ func (h *pipelineHarness) configure(codec msdk.AudioCodec, audioPT, dtmfPT byte,
 	h.codec = codec
 	h.audioPT = audioPT
 	h.dtmfPT = dtmfPT
-	h.conf.opts = &MediaOptions{DTMFAudio: dtmfAudio}
+	h.conf.opts = &MediaOptions{DTMFAudio: dtmfAudio, EnableJitterBuffer: h.jitter}
 
 	pipe, err := NewMediaPortPipeline(h.conf, h.mediaConfig(), h.port, h.audioIn, h.dtmfIn, h.audioIn.SampleRate())
 	require.NoError(h.t, err)


### PR DESCRIPTION
## Summary

Inbound audio on a SIP call went permanently silent after a PBX transfer (auto-attendant -> extension) while signalling, outbound audio and the media timeout all stayed healthy. Reproduced 5/5 on transfer calls.

- After the transfer the far end keeps the same 5-tuple but relays a different source, so the service sees a **new SSRC with an unrelated sequence-number space**. On the captured call the old stream was near seq 21294 and the new one started at 12676.
- All SSRCs on a port shared **one** `jitter.Buffer` (`rtp.HandleJitter` wrapped once in `setupInput`). That buffer drops anything up to 32768 behind its last popped sequence number and never advances on a drop, so every packet of the new stream was discarded: 8618 packets, ~172 s at 50 pps, longer than the rest of the call.
- The media timeout never fires because packets are counted before the handler chain, and the mid-dialog re-INVITE is answered with the cached SDP without touching the pipeline, so nothing reset the buffer.

## Changes

- `mediaPortPipeline` keeps the inbound chain jitter-free (`inputChain`), and each RTP read stream (one per SSRC) wraps it in its **own** jitter buffer via `newStreamHandler()`. A no-op-close wrapper stops a finishing stream from closing the shared mux, and each read loop closes only its own buffer on exit, before `Close()` tears down the chain.
- Per-buffer loss/drop counters are folded into `PortStats` as **deltas**. `jitter_buffer_packets_lost` / `_dropped` on the `call statistics` line are now the monotonic sum across all SSRCs and pipeline rebuilds of a call; previously they were one buffer's cumulative count and could regress on renegotiation.
- With `enable_jitter_buffer: false` the chain is unchanged.

## Tests

- `TestMediaPipelineJitterNewSSRCBackwardSeq`: two SSRCs through a real UDP socket with the captured sequence numbers. Fails on main with 15 dropped packets and no room audio; passes here.
- `TestMediaPipelineJitterStatsAccumulateAcrossSSRC`: loss stats sum across buffers.
- `TestMediaPipelineTeardownMultiSSRC` and `TestMediaPipelineConcurrentSSRCPump` now run with jitter on and off under `-race`.
- Full `go test -race ./pkg/...` and `./test/integration/...` pass locally.

## Related

- Companion media-sdk change so a far end that keeps its SSRC but restarts sequence numbers also resyncs: https://github.com/livekit/media-sdk/pull/86. A guard test for that case is ready to land with the dependency bump once it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MND95Kk3MD7828eZBw8ipa
